### PR TITLE
docs: add Git Bash workaround for virtual env activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ Ready to build your AI agent? Simply run this command:
 ```bash
 # Create and activate a Python virtual environment
 python -m venv venv && source venv/bin/activate
-
+```
+**Note:**  If that doesn't work (rare case in Git Bash on Windows), try: 
+```bash
+. venv/Scripts/activate
+```
+```bash
 # Install the agent starter pack
 pip install agent-starter-pack
 


### PR DESCRIPTION
Some Windows users using Git Bash may encounter issues with `source venv/bin/activate` due to path differences. This PR adds a note suggesting. venv/Scripts/activate` as a workaround. This helps avoid confusion and improves the onboarding experience for new users.

Test Note (For Reviewers)
One test (TestCreateCommand::test_create_existing_project_dir) failed during local testing on Windows.
The failure appears to be due to a platform-specific path formatting issue (C:\ vs \) when using Path() on Windows. This is unrelated to the documentation change in this PR and should not affect functionality or behavior.
All other tests passed.