### PR TITLE
feat: move uv to use locked, avoid frozen during sync

### DIFF
--- a/.cloudbuild/cd/test_e2e.yaml
+++ b/.cloudbuild/cd/test_e2e.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |
-        uv sync --dev --frozen
+        uv sync --dev --locked
 
   # Run unit tests using pytest
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"

--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |
-        uv sync --dev --extra lint --frozen
+        uv sync --dev --extra lint --locked
 
   # Run unit tests using pytest
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"

--- a/.cloudbuild/ci/lint_templated_agents.yaml
+++ b/.cloudbuild/ci/lint_templated_agents.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |
-        uv sync --frozen
+        uv sync --locked
 
   # Run unit tests using pytest
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"

--- a/.cloudbuild/ci/test.yaml
+++ b/.cloudbuild/ci/test.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |
-        uv sync --dev --frozen
+        uv sync --dev --locked
 
   # Run unit tests using pytest
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"

--- a/.cloudbuild/ci/test_templated_agents.yaml
+++ b/.cloudbuild/ci/test_templated_agents.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |
-        uv sync --frozen
+        uv sync --locked
 
   # Run unit tests using pytest
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"

--- a/src/base_template/Makefile
+++ b/src/base_template/Makefile
@@ -1,7 +1,7 @@
 # Install dependencies using uv package manager
 install:
 	@command -v uv >/dev/null 2>&1 || { echo "uv is not installed. Installing uv..."; curl -LsSf https://astral.sh/uv/0.6.12/install.sh | sh; source $HOME/.local/bin/env; }
-	uv sync --dev{% if cookiecutter.agent_name != 'live_api' and "adk" not in cookiecutter.tags %} --extra streamlit{%- endif %} --extra jupyter --frozen{% if cookiecutter.agent_name == 'live_api' %} && npm --prefix frontend install{%- endif %}
+	uv sync --dev{% if cookiecutter.agent_name != 'live_api' and "adk" not in cookiecutter.tags %} --extra streamlit{%- endif %} --extra jupyter{% if cookiecutter.agent_name == 'live_api' %} && npm --prefix frontend install{%- endif %}
 {%- if cookiecutter.settings.get("commands", {}).get("override", {}).get("install") %} && {{cookiecutter.settings.get("commands", {}).get("override", {}).get("install")}}{%- endif %}
 {%- if cookiecutter.settings.get("commands", {}).get("extra", {}) %}
 {%- for cmd_name, cmd_value in cookiecutter.settings.get("commands", {}).get("extra", {}).items() %}
@@ -67,8 +67,8 @@ backend:
 		$(if $(PORT),--port=$(PORT))
 {%- elif cookiecutter.deployment_target == 'agent_engine' %}
 	# Export dependencies to requirements file using uv export.
-	uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate --frozen > .requirements.txt 2>/dev/null || \
-	uv export --no-hashes --no-header --no-dev --no-emit-project --frozen > .requirements.txt && uv run app/agent_engine_app.py
+	uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > .requirements.txt 2>/dev/null || \
+	uv export --no-hashes --no-header --no-dev --no-emit-project > .requirements.txt && uv run app/agent_engine_app.py
 {%- endif %}
 {%- if cookiecutter.deployment_target == 'cloud_run' %}
 

--- a/src/base_template/deployment/cd/deploy-to-prod.yaml
+++ b/src/base_template/deployment/cd/deploy-to-prod.yaml
@@ -21,7 +21,7 @@ steps:
       - -c
       - |
         cd data_ingestion && pip install uv==0.6.12 --user && cd data_ingestion_pipeline && \
-        uv sync --frozen && uv run python submit_pipeline.py
+        uv sync --locked && uv run python submit_pipeline.py
     env:
       - "PIPELINE_ROOT=${_PIPELINE_GCS_ROOT}"
       - "REGION=${_REGION}"
@@ -78,7 +78,7 @@ steps:
     args:
       - "-c"
       - |
-        pip install uv==0.6.12 --user && uv sync --frozen
+        pip install uv==0.6.12 --user && uv sync --locked
     env:
       - 'PATH=/usr/local/bin:/usr/bin:~/.local/bin'
 
@@ -88,7 +88,7 @@ steps:
     args:
       - "-c"
       - |
-        uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --frozen > .requirements.txt
+        uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --locked > .requirements.txt
         uv run app/agent_engine_app.py \
           --project ${_PROD_PROJECT_ID} \
           --location ${_REGION} \

--- a/src/base_template/deployment/cd/staging.yaml
+++ b/src/base_template/deployment/cd/staging.yaml
@@ -21,7 +21,7 @@ steps:
       - -c
       - |
         cd data_ingestion && pip install uv==0.6.12 --user && cd data_ingestion_pipeline && \
-        uv sync --frozen && uv run python submit_pipeline.py
+        uv sync --locked && uv run python submit_pipeline.py
     env:
       - "PIPELINE_ROOT=${_PIPELINE_GCS_ROOT}"
       - "REGION=${_REGION}"
@@ -111,7 +111,7 @@ steps:
     args:
       - "-c"
       - |
-        pip install uv==0.6.12 --user && uv sync --frozen
+        pip install uv==0.6.12 --user && uv sync --locked
     env:
       - 'PATH=/usr/local/bin:/usr/bin:~/.local/bin'
 
@@ -121,7 +121,7 @@ steps:
     args:
       - "-c"
       - |
-        uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --frozen > .requirements.txt
+        uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --locked > .requirements.txt
         uv run app/agent_engine_app.py \
           --project ${_STAGING_PROJECT_ID} \
           --location ${_REGION} \
@@ -149,7 +149,7 @@ steps:
 {%- if cookiecutter.deployment_target == 'cloud_run' %}
         export _ID_TOKEN=$(cat id_token.txt)
         export _STAGING_URL=$(cat staging_url.txt)
-        pip install uv==0.6.12 --user && uv sync --frozen
+        pip install uv==0.6.12 --user && uv sync --locked
 {%- elif cookiecutter.deployment_target == 'agent_engine' %}
         export _AUTH_TOKEN=$(cat auth_token.txt)
 {%- endif %}

--- a/src/base_template/deployment/ci/pr_checks.yaml
+++ b/src/base_template/deployment/ci/pr_checks.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |
-        pip install uv==0.6.12 --user && uv sync --frozen
+        pip install uv==0.6.12 --user && uv sync --locked
     env:
       - 'PATH=/usr/local/bin:/usr/bin:~/.local/bin'
 


### PR DESCRIPTION

This pull request refactors our CI/CD pipelines and local development tooling to adopt the `--locked` flag for `uv sync` and `uv export` commands, replacing the previous usage of `--frozen`.

#### Motivation

The `--frozen` flag prevents `uv` from updating the lock file, which is desirable in a CI environment. However, it does not validate that the `uv.lock` file is actually in sync with the `pyproject.toml` specifications. This can lead to a subtle but critical issue where a developer might change `pyproject.toml` but forget to regenerate and commit the `uv.lock` file. The CI pipeline would then succeed using an outdated lock file, creating a discrepancy between the intended dependencies and the ones being tested and deployed.

By switching to `--locked`, we enforce a stricter contract. The `--locked` flag asserts that the `uv.lock` is a perfect representation of `pyproject.toml` and will cause the build to **fail** if they are out of sync. This makes our builds:
- **More Reliable:** Fail-fast behavior immediately catches dependency inconsistencies.
- **More Reproducible:** Guarantees that the exact dependency set committed by the developer is used in CI.
- **Easier to Debug:** Eliminates an entire class of "works on my machine" problems related to dependencies.

#### Changes Implemented

1.  **CI/CD Pipelines (`.cloudbuild/`, `deployment/`):**
    - All instances of `uv sync --frozen` have been replaced with `uv sync --locked`.
    - All instances of `uv export --frozen` have been replaced with `uv export --locked`.
    - This applies to all linting, testing, and deployment jobs, ensuring consistent and strict dependency installation across the entire pipeline.

2.  **Local Development (`src/base_template/Makefile`):**
    - The `--frozen` flag has been **removed** from the `install` target. This improves the local developer experience by allowing `uv sync` to behave as expected: automatically updating `uv.lock` if `pyproject.toml` has been changed.
    - The `--frozen` flag was also removed from the `uv export` command in the `backend` target to align with the more flexible nature of local development tasks.