### PR TITLE
fix: load tests to be resistant to 429s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ testem.log
 Thumbs.db
 *.vscode*
 
+.locust_env/
 .saved_chats
 .aider*
 target

--- a/src/base_template/deployment/cd/staging.yaml
+++ b/src/base_template/deployment/cd/staging.yaml
@@ -135,12 +135,11 @@ steps:
 {%- if cookiecutter.deployment_target == 'cloud_run' %}
         export _ID_TOKEN=$(cat id_token.txt)
         export _STAGING_URL=$(cat staging_url.txt)
-        pip install uv==0.6.12 --user && uv sync --locked
 {%- elif cookiecutter.deployment_target == 'agent_engine' %}
         export _AUTH_TOKEN=$(cat auth_token.txt)
 {%- endif %}
-        uv add locust==2.32.6
-        uv run locust -f tests/load_test/load_test.py \
+        pip install locust==2.31.1 --user
+        locust -f tests/load_test/load_test.py \
         --headless \
 {%- if cookiecutter.deployment_target == 'cloud_run' %}
         -H $$_STAGING_URL \

--- a/src/deployment_targets/agent_engine/tests/load_test/README.md
+++ b/src/deployment_targets/agent_engine/tests/load_test/README.md
@@ -18,12 +18,7 @@ Follow these steps to execute load tests:
    It's recommended to use a separate terminal tab and create a virtual environment for Locust to avoid conflicts with your application's Python environment.
 
    ```bash
-   # Create and activate virtual environment
-   python3 -m venv .locust_env
-   source .locust_env/bin/activate
-   
-   # Install required packages
-   pip install locust==2.31.1 "google-cloud-aiplatform[langchain,reasoningengine]>=1.77.0"
+   python3 -m venv .locust_env && source .locust_env/bin/activate && pip install locust==2.31.1
    ```
 
 **3. Execute the Load Test:**


### PR DESCRIPTION
This PR improves the resilience of the load tests for both `cloud_run` and `agent_engine` deployments by properly handling `429 Too Many Requests` errors that occur mid-stream.

#### Problem

The existing load tests establish a streaming connection and expect a `200 OK` status. However, the backend service can begin rate-limiting partway through the stream, sending `429` error messages within the response body. The previous implementation did not distinguish these in-stream errors, potentially leading to misleading test results or premature test failures. The test would either fail entirely or simply not account for the rate-limiting events.

#### Solution

The load test scripts (`load_test.py`) have been updated to inspect each line of the streaming response.

1.  **Detect In-Stream 429s:** If a line contains the "429 Too Many Requests" string, the test now fires a dedicated, non-failing Locust event with the name `... rate_limited 429s`.
2.  **Continue Processing:** The test then uses `continue` to proceed to the next line in the stream, allowing the overall request to complete successfully.

This change ensures that the load test can continue running even when encountering rate-limiting, while still providing clear visibility into how frequently these 429 errors occur in the final Locust report.

#### Other Changes

*   **CI Dependency Management:** Reverted the load test installation step in `staging.yaml` from `uv` back to `pip`. This simplifies the CI setup and resolves potential tooling inconsistencies.
*   **Documentation:** Simplified the local load test setup instructions in `README.md` into a single, chained command.
*   **Metric Correction:** Corrected the `response_length` calculation for the final "end" event to report the number of events received, rather than the byte length of the serialized events.