### PR TITLE
fix: add UTF-8 encoding to file operations in template and Makefile handling

### DIFF
--- a/src/base_template/Makefile
+++ b/src/base_template/Makefile
@@ -4,7 +4,7 @@ install:
 {%- if cookiecutter.settings.get("commands", {}).get("override", {}).get("install") %} 
 	{{cookiecutter.settings.get("commands", {}).get("override", {}).get("install")}}
 {%- else %}
-	uv sync --dev{% if cookiecutter.agent_name != 'live_api' and "adk" not in cookiecutter.tags %} --extra streamlit{%- endif %} --extra jupyter{% if cookiecutter.agent_name == 'live_api' %} && npm --prefix frontend install{%- endif %}
+	uv sync --dev{% if cookiecutter.agent_name != 'live_api' and "adk" not in cookiecutter.tags %} --extra streamlit{%- endif %} --extra jupyter{% if cookiecutter.agent_name == 'live_api' %} && cd frontend && npm install{%- endif %}
 {%- endif %}
 
 {%- if cookiecutter.settings.get("commands", {}).get("extra", {}) %}

--- a/src/cli/utils/remote_template.py
+++ b/src/cli/utils/remote_template.py
@@ -198,7 +198,7 @@ def load_remote_template_config(template_dir: pathlib.Path) -> dict[str, Any]:
         return {}
 
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f)
             return config if config else {}
     except Exception as e:
@@ -265,7 +265,7 @@ def render_and_merge_makefiles(
     # Render the base Makefile
     base_makefile_path = base_template_path / "Makefile"
     if base_makefile_path.exists():
-        with open(base_makefile_path) as f:
+        with open(base_makefile_path, encoding="utf-8") as f:
             base_template = env.from_string(f.read())
         rendered_base_makefile = base_template.render(cookiecutter=cookiecutter_config)
     else:
@@ -276,7 +276,7 @@ def render_and_merge_makefiles(
     if remote_template_path:
         remote_makefile_path = remote_template_path / "Makefile"
         if remote_makefile_path.exists():
-            with open(remote_makefile_path) as f:
+            with open(remote_makefile_path, encoding="utf-8") as f:
                 remote_template = env.from_string(f.read())
             rendered_remote_makefile = remote_template.render(
                 cookiecutter=cookiecutter_config
@@ -316,6 +316,6 @@ def render_and_merge_makefiles(
         final_makefile_content = rendered_base_makefile
 
     # Write the final merged Makefile
-    with open(final_destination / "Makefile", "w") as f:
+    with open(final_destination / "Makefile", "w", encoding="utf-8") as f:
         f.write(final_makefile_content)
     logging.debug("Rendered and merged Makefile written to final destination.")

--- a/src/cli/utils/template.py
+++ b/src/cli/utils/template.py
@@ -48,7 +48,7 @@ class TemplateConfig:
     def from_file(cls, config_path: pathlib.Path) -> "TemplateConfig":
         """Load template config from file with validation"""
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             if not isinstance(data, dict):
@@ -101,7 +101,7 @@ def get_available_agents(deployment_target: str | None = None) -> dict:
             template_config_path = agent_dir / ".template" / "templateconfig.yaml"
             if template_config_path.exists():
                 try:
-                    with open(template_config_path) as f:
+                    with open(template_config_path, encoding="utf-8") as f:
                         config = yaml.safe_load(f)
                     agent_name = agent_dir.name
 
@@ -150,7 +150,7 @@ def load_template_config(template_dir: pathlib.Path) -> dict[str, Any]:
         return {}
 
     try:
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             config = yaml.safe_load(f)
             return config if config else {}
     except Exception as e:
@@ -585,13 +585,13 @@ def process_template(
                 / "docs"
                 / "adk-cheatsheet.md"
             )
-            with open(adk_cheatsheet_path) as f:
+            with open(adk_cheatsheet_path, encoding="utf-8") as f:
                 adk_cheatsheet_content = f.read()
 
             llm_txt_path = (
                 pathlib.Path(__file__).parent.parent.parent.parent / "llm.txt"
             )
-            with open(llm_txt_path) as f:
+            with open(llm_txt_path, encoding="utf-8") as f:
                 llm_txt_content = f.read()
 
             cookiecutter_config = {
@@ -629,7 +629,9 @@ def process_template(
                 ],
             }
 
-            with open(cookiecutter_template / "cookiecutter.json", "w") as f:
+            with open(
+                cookiecutter_template / "cookiecutter.json", "w", encoding="utf-8"
+            ) as f:
                 json.dump(cookiecutter_config, f, indent=4)
 
             logging.debug(f"Template structure created at {cookiecutter_template}")

--- a/tests/cli/utils/test_remote_template.py
+++ b/tests/cli/utils/test_remote_template.py
@@ -464,7 +464,7 @@ class TestRenderAndMergeMakefiles:
         )
 
         # Check that the final Makefile was written correctly
-        mock_file.assert_called_with(dest_path / "Makefile", "w")
+        mock_file.assert_called_with(dest_path / "Makefile", "w", encoding="utf-8")
         handle = mock_file()
         written_content = handle.write.call_args[0][0]
 


### PR DESCRIPTION
Fixes FileNotFoundError: [WinError 2] on Windows by adding explicit UTF-8 encoding to file operations in template processing and Makefile handling.

Fixes: #67

Changes:

Added [encoding="utf-8"](vscode-file://vscode-app/c:/Users/matea/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to file operations in [template.py](vscode-file://vscode-app/c:/Users/matea/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and remote_template.py
Updated Makefile template rendering for Windows compatibility
Testing: Verified on Windows systems, no impact on Linux/macOS.