### PR TITLE
Fix: Add missing import for SequentialAgent

### DIFF
--- a/src/resources/docs/adk-cheatsheet.md
+++ b/src/resources/docs/adk-cheatsheet.md
@@ -356,7 +356,7 @@ document_pipeline = SequentialAgent(
 Executes `sub_agents` simultaneously. Useful for independent tasks to reduce overall latency. All sub-agents share the same `session.state`.
 
 ```python
-from google.adk.agents import ParallelAgent, Agent
+from google.adk.agents import ParallelAgent, Agent, SequentialAgent
 
 # Agents to fetch data concurrently
 fetch_stock_price = Agent(name="StockPriceFetcher", ..., output_key="stock_data")


### PR DESCRIPTION
Fix: SequentialAgent was used in the example code but was not imported, leading to a NameError. Added SequentialAgent to the import statement.