### PR TITLE
feat: add labels cr agent garden

### DIFF
--- a/src/base_template/Makefile
+++ b/src/base_template/Makefile
@@ -76,7 +76,7 @@ backend:
 		--region "us-central1" \
 		--no-allow-unauthenticated \
 		--no-cpu-throttling \
-		--labels "created-by=adk{%- if cookiecutter.agent_garden %},deployed-with=agent-garden{%- if cookiecutter.agent_sample_id %},vertex-agent-sample-id={{cookiecutter.agent_sample_id}},vertex-agent-sample-publisher={{cookiecutter.agent_sample_publisher}}{%- endif %}{%- endif %}" \
+		--labels "{% if "adk" in cookiecutter.tags %}created-by=adk{% if cookiecutter.agent_garden %},{% endif %}{% endif %}{% if cookiecutter.agent_garden %}deployed-with=agent-garden{% if cookiecutter.agent_sample_id %},vertex-agent-sample-id={{cookiecutter.agent_sample_id}},vertex-agent-sample-publisher={{cookiecutter.agent_sample_publisher}}{% endif %}{% endif %}" \
 		--set-env-vars \
 		"COMMIT_SHA=$(shell git rev-parse HEAD){%- if cookiecutter.data_ingestion %}{%- if cookiecutter.datastore_type == "vertex_ai_search" %},DATA_STORE_ID={{cookiecutter.project_name}}-datastore,DATA_STORE_REGION=us{%- elif cookiecutter.datastore_type == "vertex_ai_vector_search" %},VECTOR_SEARCH_INDEX={{cookiecutter.project_name}}-vector-search,VECTOR_SEARCH_INDEX_ENDPOINT={{cookiecutter.project_name}}-vector-search-endpoint,VECTOR_SEARCH_BUCKET=$$PROJECT_ID-{{cookiecutter.project_name}}-vs{%- endif %}{%- endif %}" \
 		$(if $(IAP),--iap) \

--- a/src/base_template/Makefile
+++ b/src/base_template/Makefile
@@ -76,7 +76,7 @@ backend:
 		--region "us-central1" \
 		--no-allow-unauthenticated \
 		--no-cpu-throttling \
-		--labels "created-by=adk{%- if cookiecutter.agent_garden %},deployed-with=agent-garden{%- endif %}" \
+		--labels "created-by=adk{%- if cookiecutter.agent_garden %},deployed-with=agent-garden{%- if cookiecutter.agent_sample_id %},vertex-agent-sample-id={{cookiecutter.agent_sample_id}},vertex-agent-sample-publisher={{cookiecutter.agent_sample_publisher}}{%- endif %}{%- endif %}" \
 		--set-env-vars \
 		"COMMIT_SHA=$(shell git rev-parse HEAD){%- if cookiecutter.data_ingestion %}{%- if cookiecutter.datastore_type == "vertex_ai_search" %},DATA_STORE_ID={{cookiecutter.project_name}}-datastore,DATA_STORE_REGION=us{%- elif cookiecutter.datastore_type == "vertex_ai_vector_search" %},VECTOR_SEARCH_INDEX={{cookiecutter.project_name}}-vector-search,VECTOR_SEARCH_INDEX_ENDPOINT={{cookiecutter.project_name}}-vector-search-endpoint,VECTOR_SEARCH_BUCKET=$$PROJECT_ID-{{cookiecutter.project_name}}-vs{%- endif %}{%- endif %}" \
 		$(if $(IAP),--iap) \

--- a/src/base_template/deployment/terraform/vars/env.tfvars
+++ b/src/base_template/deployment/terraform/vars/env.tfvars
@@ -13,7 +13,10 @@ cicd_runner_project_id = "your-cicd-project-id"
 {%- if cookiecutter.cicd_runner == "google_cloud_build" %}
 # Name of the host connection you created in Cloud Build
 host_connection_name = "git-{{cookiecutter.project_name}}"
+github_pat_secret_id = "your-github_pat_secret_id"
 {%- endif %}
+
+repository_owner = "Your GitHub organization or username."
 
 # Name of the repository you added to Cloud Build
 repository_name = "{{cookiecutter.project_name}}"
@@ -33,8 +36,4 @@ vector_search_machine_type = "e2-standard-2"
 vector_search_min_replica_count = 1
 vector_search_max_replica_count = 1
 {%- endif %}
-{%- endif %}
-{%- if cookiecutter.cicd_runner == "github_actions" %}
-
-repository_owner = "Your GitHub organization or username."
 {%- endif %}

--- a/src/cli/commands/create.py
+++ b/src/cli/commands/create.py
@@ -712,6 +712,7 @@ def create(
                 in_folder=in_folder,
                 cli_overrides=final_cli_overrides,
                 agent_garden=agent_garden,
+                remote_spec=remote_spec,
             )
 
             # Replace region in all files if a different region was specified

--- a/src/cli/utils/template.py
+++ b/src/cli/utils/template.py
@@ -532,7 +532,7 @@ def process_template(
             agent_sample_publisher = None
             if agent_garden and remote_spec and remote_spec.is_adk_samples:
                 # For ADK samples, template_path is like "python/agents/sample-name"
-                agent_sample_id = remote_spec.template_path.split("/")[-1]
+                agent_sample_id = pathlib.Path(remote_spec.template_path).name
                 # For ADK samples, publisher is always "google"
                 agent_sample_publisher = "google"
 

--- a/src/cli/utils/template.py
+++ b/src/cli/utils/template.py
@@ -449,6 +449,7 @@ def process_template(
     in_folder: bool = False,
     cli_overrides: dict[str, Any] | None = None,
     agent_garden: bool = False,
+    remote_spec: Any | None = None,
 ) -> None:
     """Process the template directory and create a new project.
 
@@ -525,6 +526,15 @@ def process_template(
 
         try:
             os.chdir(temp_path)  # Change to temp directory
+
+            # Extract agent sample info for labeling when using agent garden with remote templates
+            agent_sample_id = None
+            agent_sample_publisher = None
+            if agent_garden and remote_spec and remote_spec.is_adk_samples:
+                # For ADK samples, template_path is like "python/agents/sample-name"
+                agent_sample_id = remote_spec.template_path.split("/")[-1]
+                # For ADK samples, publisher is always "google"
+                agent_sample_publisher = "google"
 
             # Create the cookiecutter template structure
             cookiecutter_template = temp_path / "template"
@@ -706,6 +716,8 @@ def process_template(
                 "datastore_type": datastore if datastore else "",
                 "agent_directory": get_agent_directory(template_config, cli_overrides),
                 "agent_garden": agent_garden,
+                "agent_sample_id": agent_sample_id or "",
+                "agent_sample_publisher": agent_sample_publisher or "",
                 "adk_cheatsheet": adk_cheatsheet_content,
                 "llm_txt": llm_txt_content,
                 "_copy_without_render": [

--- a/src/deployment_targets/cloud_run/deployment/terraform/dev/service.tf
+++ b/src/deployment_targets/cloud_run/deployment/terraform/dev/service.tf
@@ -133,13 +133,18 @@ resource "google_cloud_run_v2_service" "app" {
   project             = var.dev_project_id
   deletion_protection = false
   ingress             = "INGRESS_TRAFFIC_ALL"
-{%- if cookiecutter.agent_garden and cookiecutter.agent_sample_id %}
-
   labels = {
-    "vertex-agent-sample-id" = "{{cookiecutter.agent_sample_id}}"
-    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
-  }
+{%- if "adk" in cookiecutter.tags %}
+    "created-by"                  = "adk"
 {%- endif %}
+{%- if cookiecutter.agent_garden %}
+    "deployed-with"               = "agent-garden"
+{%- if cookiecutter.agent_sample_id %}
+    "vertex-agent-sample-id"      = "{{cookiecutter.agent_sample_id}}"
+    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
+{%- endif %}
+{%- endif %}
+  }
 
   template {
     containers {

--- a/src/deployment_targets/cloud_run/deployment/terraform/dev/service.tf
+++ b/src/deployment_targets/cloud_run/deployment/terraform/dev/service.tf
@@ -133,6 +133,13 @@ resource "google_cloud_run_v2_service" "app" {
   project             = var.dev_project_id
   deletion_protection = false
   ingress             = "INGRESS_TRAFFIC_ALL"
+{%- if cookiecutter.agent_garden and cookiecutter.agent_sample_id %}
+
+  labels = {
+    "vertex-agent-sample-id" = "{{cookiecutter.agent_sample_id}}"
+    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
+  }
+{%- endif %}
 
   template {
     containers {

--- a/src/deployment_targets/cloud_run/deployment/terraform/service.tf
+++ b/src/deployment_targets/cloud_run/deployment/terraform/service.tf
@@ -154,6 +154,13 @@ resource "google_cloud_run_v2_service" "app_staging" {
   project             = var.staging_project_id
   deletion_protection = false
   ingress             = "INGRESS_TRAFFIC_ALL"
+{%- if cookiecutter.agent_garden and cookiecutter.agent_sample_id %}
+
+  labels = {
+    "vertex-agent-sample-id" = "{{cookiecutter.agent_sample_id}}"
+    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
+  }
+{%- endif %}
 
   template {
     containers {
@@ -260,6 +267,13 @@ resource "google_cloud_run_v2_service" "app_prod" {
   project             = var.prod_project_id
   deletion_protection = false
   ingress             = "INGRESS_TRAFFIC_ALL"
+{%- if cookiecutter.agent_garden and cookiecutter.agent_sample_id %}
+
+  labels = {
+    "vertex-agent-sample-id" = "{{cookiecutter.agent_sample_id}}"
+    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
+  }
+{%- endif %}
 
   template {
     containers {

--- a/src/deployment_targets/cloud_run/deployment/terraform/service.tf
+++ b/src/deployment_targets/cloud_run/deployment/terraform/service.tf
@@ -154,13 +154,18 @@ resource "google_cloud_run_v2_service" "app_staging" {
   project             = var.staging_project_id
   deletion_protection = false
   ingress             = "INGRESS_TRAFFIC_ALL"
-{%- if cookiecutter.agent_garden and cookiecutter.agent_sample_id %}
-
   labels = {
-    "vertex-agent-sample-id" = "{{cookiecutter.agent_sample_id}}"
-    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
-  }
+{%- if "adk" in cookiecutter.tags %}
+    "created-by"                  = "adk"
 {%- endif %}
+{%- if cookiecutter.agent_garden %}
+    "deployed-with"               = "agent-garden"
+{%- if cookiecutter.agent_sample_id %}
+    "vertex-agent-sample-id"      = "{{cookiecutter.agent_sample_id}}"
+    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
+{%- endif %}
+{%- endif %}
+  }
 
   template {
     containers {
@@ -267,13 +272,18 @@ resource "google_cloud_run_v2_service" "app_prod" {
   project             = var.prod_project_id
   deletion_protection = false
   ingress             = "INGRESS_TRAFFIC_ALL"
-{%- if cookiecutter.agent_garden and cookiecutter.agent_sample_id %}
-
   labels = {
-    "vertex-agent-sample-id" = "{{cookiecutter.agent_sample_id}}"
-    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
-  }
+{%- if "adk" in cookiecutter.tags %}
+    "created-by"                  = "adk"
 {%- endif %}
+{%- if cookiecutter.agent_garden %}
+    "deployed-with"               = "agent-garden"
+{%- if cookiecutter.agent_sample_id %}
+    "vertex-agent-sample-id"      = "{{cookiecutter.agent_sample_id}}"
+    "vertex-agent-sample-publisher" = "{{cookiecutter.agent_sample_publisher}}"
+{%- endif %}
+{%- endif %}
+  }
 
   template {
     containers {


### PR DESCRIPTION
Introduce the capability to set labels when the agent is deployed via Agent Garden in Cloud Run.

New labels being added are:
`deployed-with=agent-garden`, `vertex-agent-sample-id=the-sample-id-value`, `vertex-agent-sample-publisher=google`

Example:
```
--labels "created-by=adk,deployed-with=agent-garden,vertex-agent-sample-id=gemini-fullstack,vertex-agent-sample-publisher=google" \
```