### PR TITLE
fix: skip update message when using --agent-garden flag

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib.metadata
+import sys
 
 import click
 from rich.console import Console
@@ -48,8 +49,9 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Show the version and exit.",
 )
 def cli() -> None:
-    # Check for updates at startup
-    display_update_message()
+    # Check for updates at startup (skip if --agent-garden or -ag is used)
+    if "--agent-garden" not in sys.argv and "-ag" not in sys.argv:
+        display_update_message()
 
 
 # Register commands


### PR DESCRIPTION
## Summary
- Skip displaying the pip upgrade notification when CLI is invoked with `--agent-garden` or `-ag` flag
- Prevents unnecessary update prompts in automated Agent Garden deployments

## Changes
- Modified `src/cli/main.py` to check for agent-garden flags before displaying update message