### PR TITLE
Fix agent adk sample selection

### DIFF
--- a/agent_starter_pack/cli/main.py
+++ b/agent_starter_pack/cli/main.py
@@ -50,11 +50,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
 )
 def cli() -> None:
     # Check for updates at startup (skip if --agent-garden, -ag, or --locked is used)
-    if (
-        "--agent-garden" not in sys.argv
-        and "-ag" not in sys.argv
-        and "--locked" not in sys.argv
-    ):
+    if not any(flag in sys.argv for flag in ("--agent-garden", "-ag", "--locked")):
         display_update_message()
 
 

--- a/agent_starter_pack/cli/utils/remote_template.py
+++ b/agent_starter_pack/cli/utils/remote_template.py
@@ -172,14 +172,10 @@ def check_and_execute_with_version_lock(
 
             if agent_flag_exists:
                 # Replace remote agent spec with local path
-                modified_args = []
-                for arg in original_args:
-                    if arg == original_agent_spec:
-                        # Replace remote URL with local template directory
-                        modified_args.append(f"local@{template_dir}")
-                    else:
-                        modified_args.append(arg)
-                original_args = modified_args
+                original_args = [
+                    f"local@{template_dir}" if arg == original_agent_spec else arg
+                    for arg in original_args
+                ]
             else:
                 # Agent was selected interactively, add --agent flag
                 original_args.extend(["--agent", f"local@{template_dir}"])


### PR DESCRIPTION
When selecting an ADK sample agent interactively (option 6 → then selecting an agent like
  "academic-research"), the version lock causes it to restart the CLI, but it doesn't preserve that you already selected an
  agent. So it shows the agent selection menu again instead of proceeding with the already-selected agent.