### PR TITLE
Fix frontend_type default and None handling

### DIFF
--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -100,7 +100,7 @@ def get_overwrite_folders(agent_directory: str) -> list[str]:
 
 TEMPLATE_CONFIG_FILE = "templateconfig.yaml"
 DEPLOYMENT_FOLDERS = ["cloud_run", "agent_engine"]
-DEFAULT_FRONTEND = "streamlit"
+DEFAULT_FRONTEND = "None"
 
 
 def get_available_agents(deployment_target: str | None = None) -> dict:
@@ -1182,13 +1182,10 @@ def copy_files(
 
 def copy_frontend_files(frontend_type: str, project_template: pathlib.Path) -> None:
     """Copy files from the specified frontend folder directly to project root."""
-    # Skip copying if frontend_type is "None"
-    if frontend_type == "None":
-        logging.debug("Frontend type is 'None', skipping frontend files")
+    # Skip copying if frontend_type is "None" or empty
+    if not frontend_type or frontend_type == "None":
+        logging.debug("Frontend type is 'None' or empty, skipping frontend files")
         return
-
-    # Use default frontend if none specified
-    frontend_type = frontend_type or DEFAULT_FRONTEND
 
     # Get the frontends directory path
     frontends_path = (
@@ -1201,9 +1198,12 @@ def copy_frontend_files(frontend_type: str, project_template: pathlib.Path) -> N
         copy_files(frontends_path, project_template, overwrite=True)
     else:
         logging.warning(f"Frontend type directory not found: {frontends_path}")
-        if frontend_type != DEFAULT_FRONTEND:
+        # Don't fall back to default if it's "None" - just skip
+        if DEFAULT_FRONTEND != "None":
             logging.info(f"Falling back to default frontend: {DEFAULT_FRONTEND}")
             copy_frontend_files(DEFAULT_FRONTEND, project_template)
+        else:
+            logging.debug("No default frontend configured, skipping frontend files")
 
 
 def copy_deployment_files(

--- a/docs/guide/template-config-reference.md
+++ b/docs/guide/template-config-reference.md
@@ -27,7 +27,7 @@ This object contains fields that control the generated project's features and be
 | --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `deployment_targets`        | list(string)   | A list of deployment targets your template supports. Options: `agent_engine`, `cloud_run`.                                                  |
 | `tags`                      | list(string)   | A list of tags for categorization. The `adk` tag enables special integrations with the Agent Development Kit.                                 |
-| `frontend_type`             | string         | Specifies the frontend to use. Examples: `streamlit`, `adk_live_react`. Defaults to `streamlit`.                                             |
+| `frontend_type`             | string         | Specifies the frontend to use. Examples: `streamlit`, `adk_live_react`. Defaults to `None` (no frontend).                                    |
 | `agent_directory`           | string         | The name of the directory where agent code will be placed. Defaults to `app`. Can be overridden by the CLI `--agent-directory` parameter.    |
 | `requires_data_ingestion`   | boolean        | If `true`, the user will be prompted to configure a datastore.                                                                              |
 | `requires_session`          | boolean        | If `true`, the user will be prompted to choose a session storage type (e.g., `alloydb`) when using the `cloud_run` target.                    |


### PR DESCRIPTION
## Summary
- Changed default frontend_type from "streamlit" to "None" 
- Fixed copy_frontend_files to properly skip when frontend_type is "None"
- Prevented infinite recursion when default frontend is "None"
- Updated documentation

## Problem
Agents with `frontend_type: "None"` (like adk_base) were incorrectly getting streamlit frontend files during templating because the default was "streamlit".

## Solution
- Set DEFAULT_FRONTEND to "None" to match most agent templates
- Enhanced copy_frontend_files logic to handle "None" correctly
- Added safeguard against recursive fallback when default is "None"