### PR TITLE
fix: use correct uvx version syntax

### DIFF
--- a/agent_starter_pack/cli/utils/remote_template.py
+++ b/agent_starter_pack/cli/utils/remote_template.py
@@ -204,7 +204,7 @@ def check_and_execute_with_version_lock(
 
         try:
             # Execute uvx with the locked version
-            cmd = ["uvx", f"agent-starter-pack=={version}", *original_args]
+            cmd = ["uvx", f"agent-starter-pack@{version}", *original_args]
             logging.debug(f"Executing nested command: {' '.join(cmd)}")
             subprocess.run(cmd, check=True)
             return True


### PR DESCRIPTION
## Summary
- Fixed uvx version syntax from `==` to `@` for version pinning
- Resolves "Not a valid package or extra name" error when remote templates lock to specific agent-starter-pack versions
