### PR TITLE
fix: enable Secret Manager API in setup-cicd command

### DIFF
--- a/agent_starter_pack/cli/utils/cicd.py
+++ b/agent_starter_pack/cli/utils/cicd.py
@@ -103,9 +103,10 @@ def create_github_connection(
     """
     console.print("\n🔗 Creating GitHub connection...")
 
-    # First, ensure Cloud Build API is enabled
-    console.print("🔧 Ensuring Cloud Build API is enabled...")
+    # First, ensure required APIs are enabled
+    console.print("🔧 Ensuring required APIs are enabled...")
     try:
+        # Enable Cloud Build API
         run_command(
             [
                 "gcloud",
@@ -120,13 +121,28 @@ def create_github_connection(
         )
         console.print("✅ Cloud Build API enabled")
 
-        # Wait for the API to fully initialize and create the service account
+        # Enable Secret Manager API
+        run_command(
+            [
+                "gcloud",
+                "services",
+                "enable",
+                "secretmanager.googleapis.com",
+                "--project",
+                project_id,
+            ],
+            capture_output=True,
+            check=False,  # Don't fail if already enabled
+        )
+        console.print("✅ Secret Manager API enabled")
+
+        # Wait for the APIs to fully initialize and create the service account
         console.print(
             "⏳ Waiting for Cloud Build service account to be created (this typically takes 5-10 seconds)..."
         )
         time.sleep(10)
     except subprocess.CalledProcessError as e:
-        console.print(f"⚠️ Could not enable Cloud Build API: {e}", style="yellow")
+        console.print(f"⚠️ Could not enable required APIs: {e}", style="yellow")
 
     # Get the Cloud Build service account and grant permissions with retry logic
     try:


### PR DESCRIPTION
## Summary
- Add Secret Manager API enablement to `create_github_connection()` function
- Update console message to reflect both APIs being enabled

## Problem
The `setup-cicd` command was failing when creating GitHub connections with the error:

```
could not assert Secret Manager permissions. Make sure that Secret Manager is enabled in your GCP project
Error: generic::permission_denied: Secret Manager API has not been used in project before or it is disabled
```

The root cause was that `create_github_connection()` only enabled the Cloud Build API, but the `gcloud builds connections create github` command requires Secret Manager API to store OAuth tokens for GitHub authentication.

## Solution
Modified `create_github_connection()` in `cicd.py` to enable both required APIs:
1. Cloud Build API (`cloudbuild.googleapis.com`)
2. Secret Manager API (`secretmanager.googleapis.com`)

This ensures the Secret Manager API is available before attempting to create the GitHub connection, preventing the permission error.