### PR TITLE
Fix agent engine artifacts bucket name format

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/agent_engine_app.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/agent_engine_app.py
@@ -347,7 +347,7 @@ def deploy_agent_engine_app(
     if not staging_bucket_uri:
         staging_bucket_uri = f"gs://{project}-agent-engine"
     if not artifacts_bucket_name:
-        artifacts_bucket_name = f"gs://{project}-agent-engine"
+        artifacts_bucket_name = f"{project}-agent-engine"
 
 {%- if "adk" in cookiecutter.tags %}
     create_bucket_if_not_exists(


### PR DESCRIPTION
## Summary
- Remove incorrect `gs://` prefix from `artifacts_bucket_name` default value

## Problem
The `artifacts_bucket_name` parameter was incorrectly defaulting to `gs://{project}-agent-engine`, but this parameter expects only the bucket name, not the full URI.

## Solution
Changed the default to `{project}-agent-engine` to match the expected bucket name format, aligning with how the parameter is used in the Agent Engine deployment.