### PR TITLE
refactor: use module execution for agent_engine_app

### DIFF
--- a/agent_starter_pack/base_template/Makefile
+++ b/agent_starter_pack/base_template/Makefile
@@ -180,7 +180,7 @@ deploy:
 {%- elif cookiecutter.deployment_target == 'agent_engine' %}
 	# Export dependencies to requirements file using uv export.
 	uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > .requirements.txt 2>/dev/null || \
-	uv export --no-hashes --no-header --no-dev --no-emit-project > .requirements.txt && uv run {{cookiecutter.agent_directory}}/agent_engine_app.py
+	uv export --no-hashes --no-header --no-dev --no-emit-project > .requirements.txt && uv run -m {{cookiecutter.agent_directory}}.agent_engine_app
 {%- endif %}
 
 # Alias for 'make deploy' for backward compatibility

--- a/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'github_actions' %}.github{% else %}unused_github{% endif %}/workflows/deploy-to-prod.yaml
+++ b/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'github_actions' %}.github{% else %}unused_github{% endif %}/workflows/deploy-to-prod.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Deploy to Production (Agent Engine)
         run: |
           uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --locked > .requirements.txt
-          uv run {{cookiecutter.agent_directory}}/agent_engine_app.py \
+          uv run -m {{cookiecutter.agent_directory}}.agent_engine_app \
             --project {% raw %}${{ vars.PROD_PROJECT_ID }}{% endraw %} \
             --location {% raw %}${{ vars.REGION }}{% endraw %} \
             --artifacts-bucket-name {% raw %}${{ vars.LOGS_BUCKET_NAME_PROD }}{% endraw %} \

--- a/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'github_actions' %}.github{% else %}unused_github{% endif %}/workflows/staging.yaml
+++ b/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'github_actions' %}.github{% else %}unused_github{% endif %}/workflows/staging.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: Deploy to Staging (Agent Engine)
         run: |
           uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --locked > .requirements.txt
-          uv run {{cookiecutter.agent_directory}}/agent_engine_app.py \
+          uv run -m {{cookiecutter.agent_directory}}.agent_engine_app \
             --project {% raw %}${{ vars.STAGING_PROJECT_ID }}{% endraw %} \
             --location {% raw %}${{ vars.REGION }}{% endraw %} \
             --artifacts-bucket-name {% raw %}${{ vars.LOGS_BUCKET_NAME_STAGING }}{% endraw %} \

--- a/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'google_cloud_build' %}.cloudbuild{% else %}unused_.cloudbuild{% endif %}/deploy-to-prod.yaml
+++ b/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'google_cloud_build' %}.cloudbuild{% else %}unused_.cloudbuild{% endif %}/deploy-to-prod.yaml
@@ -89,7 +89,7 @@ steps:
         AGENT_VERSION=$(cat /workspace/agent_version.txt || echo '0.0.0')
 {%- endif %}
         uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --locked > .requirements.txt
-        uv run {{cookiecutter.agent_directory}}/agent_engine_app.py \
+        uv run -m {{cookiecutter.agent_directory}}.agent_engine_app \
           --project ${_PROD_PROJECT_ID} \
           --location ${_REGION} \
           --artifacts-bucket-name ${_LOGS_BUCKET_NAME_PROD} \

--- a/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'google_cloud_build' %}.cloudbuild{% else %}unused_.cloudbuild{% endif %}/staging.yaml
+++ b/agent_starter_pack/base_template/{% if cookiecutter.cicd_runner == 'google_cloud_build' %}.cloudbuild{% else %}unused_.cloudbuild{% endif %}/staging.yaml
@@ -139,7 +139,7 @@ steps:
         AGENT_VERSION=$(cat /workspace/agent_version.txt || echo '0.0.0')
 {%- endif %}
         uv export --no-hashes --no-sources --no-header --no-dev --no-emit-project --no-annotate --locked > .requirements.txt
-        uv run {{cookiecutter.agent_directory}}/agent_engine_app.py \
+        uv run -m {{cookiecutter.agent_directory}}.agent_engine_app \
           --project ${_STAGING_PROJECT_ID} \
           --location ${_REGION} \
           --artifacts-bucket-name ${_LOGS_BUCKET_NAME_STAGING} \


### PR DESCRIPTION
## Summary
- Change agent_engine_app execution from file path to module-based approach
- Update Makefile and all CI/CD pipelines (GitHub Actions & Cloud Build)

## Changes
Use `uv run -m {{cookiecutter.agent_directory}}.agent_engine_app` instead of `uv run {{cookiecutter.agent_directory}}/agent_engine_app.py` across:
- Makefile deploy target
- GitHub Actions staging and production workflows
- Cloud Build staging and production configurations

## Benefits
- More Pythonic and consistent with other module invocations in the codebase
- Cleaner syntax without explicit `python` command
- Better alignment with Python best practices