### PR TITLE
Add register-gemini-enterprise to CLI sidebar

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -112,6 +112,7 @@ export default defineConfig({
           { text: 'create', link: '/cli/create' },
           { text: 'enhance', link: '/cli/enhance' },
           { text: 'list', link: '/cli/list' },
+          { text: 'register-gemini-enterprise', link: '/cli/register_gemini_enterprise' },
           { text: 'setup-cicd', link: '/cli/setup_cicd' }
         ]
       },


### PR DESCRIPTION
## Summary
- Add `register-gemini-enterprise` to CLI Commands section in sidebar

## Problem
The `register-gemini-enterprise` CLI command documentation exists but is not visible in the left navigation sidebar.

## Solution
Add the command to the VitePress sidebar configuration in alphabetical order between `list` and `setup-cicd`.