### PR TITLE
Refactor Agent Garden label extraction for improved maintainability

### DIFF
--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -17,6 +17,7 @@ import logging
 import os
 import pathlib
 import shutil
+import sys
 import tempfile
 from dataclasses import dataclass
 from typing import Any
@@ -459,6 +460,72 @@ def copy_data_ingestion_files(
         )
 
 
+def _extract_agent_garden_labels(
+    agent_garden: bool,
+    remote_spec: Any | None,
+    remote_template_path: pathlib.Path | None,
+) -> tuple[str | None, str | None]:
+    """Extract agent sample ID and publisher for Agent Garden labeling.
+
+    This function supports two mechanisms for extracting label information:
+    1. From remote_spec metadata (for ADK samples)
+    2. Fallback to pyproject.toml parsing (for version-locked templates)
+
+    Args:
+        agent_garden: Whether this deployment is from Agent Garden
+        remote_spec: Remote template spec with ADK samples metadata
+        remote_template_path: Path to remote template directory
+
+    Returns:
+        Tuple of (agent_sample_id, agent_sample_publisher) or (None, None) if no labels found
+    """
+    if not agent_garden:
+        return None, None
+
+    agent_sample_id = None
+    agent_sample_publisher = None
+
+    # Handle remote specs with ADK samples metadata
+    if (
+        remote_spec
+        and hasattr(remote_spec, "is_adk_samples")
+        and remote_spec.is_adk_samples
+    ):
+        # For ADK samples, template_path is like "python/agents/sample-name"
+        agent_sample_id = pathlib.Path(remote_spec.template_path).name
+        # For ADK samples, publisher is always "google"
+        agent_sample_publisher = "google"
+        logging.debug(f"Detected ADK sample from remote_spec: {agent_sample_id}")
+        return agent_sample_id, agent_sample_publisher
+
+    # Fallback: Detect ADK samples from pyproject.toml (for version-locked templates)
+    if remote_template_path:
+        pyproject_path = remote_template_path / "pyproject.toml"
+        if pyproject_path.exists():
+            try:
+                if sys.version_info >= (3, 11):
+                    import tomllib
+                else:
+                    import tomli as tomllib
+
+                with open(pyproject_path, "rb") as f:
+                    pyproject_data = tomllib.load(f)
+
+                # Extract project name from pyproject.toml
+                project_name_from_toml = pyproject_data.get("project", {}).get("name")
+
+                if project_name_from_toml:
+                    agent_sample_id = project_name_from_toml
+                    agent_sample_publisher = "google"  # ADK samples are from Google
+                    logging.debug(
+                        f"Detected ADK sample from pyproject.toml: {agent_sample_id}"
+                    )
+            except Exception as e:
+                logging.debug(f"Failed to read pyproject.toml: {e}")
+
+    return agent_sample_id, agent_sample_publisher
+
+
 def process_template(
     agent_name: str,
     template_dir: pathlib.Path,
@@ -560,48 +627,9 @@ def process_template(
             os.chdir(temp_path)  # Change to temp directory
 
             # Extract agent sample info for labeling when using agent garden with remote templates
-            agent_sample_id = None
-            agent_sample_publisher = None
-
-            # Handle remote specs with ADK samples metadata
-            if agent_garden and remote_spec and remote_spec.is_adk_samples:
-                # For ADK samples, template_path is like "python/agents/sample-name"
-                agent_sample_id = pathlib.Path(remote_spec.template_path).name
-                # For ADK samples, publisher is always "google"
-                agent_sample_publisher = "google"
-                logging.debug(
-                    f"Detected ADK sample from remote_spec: {agent_sample_id}"
-                )
-            # Fallback: Detect ADK samples from pyproject.toml (for version-locked templates)
-            elif agent_garden and remote_template_path:
-                pyproject_path = remote_template_path / "pyproject.toml"
-                if pyproject_path.exists():
-                    try:
-                        import sys
-
-                        if sys.version_info >= (3, 11):
-                            import tomllib
-                        else:
-                            import tomli as tomllib
-
-                        with open(pyproject_path, "rb") as f:
-                            pyproject_data = tomllib.load(f)
-
-                        # Extract project name from pyproject.toml
-                        project_name_from_toml = pyproject_data.get("project", {}).get(
-                            "name"
-                        )
-
-                        if project_name_from_toml:
-                            agent_sample_id = project_name_from_toml
-                            agent_sample_publisher = (
-                                "google"  # ADK samples are from Google
-                            )
-                            logging.debug(
-                                f"Detected ADK sample from pyproject.toml: {agent_sample_id}"
-                            )
-                    except Exception as e:
-                        logging.debug(f"Failed to read pyproject.toml: {e}")
+            agent_sample_id, agent_sample_publisher = _extract_agent_garden_labels(
+                agent_garden, remote_spec, remote_template_path
+            )
 
             # Create the cookiecutter template structure
             cookiecutter_template = temp_path / "template"

--- a/tests/cli/utils/test_remote_template.py
+++ b/tests/cli/utils/test_remote_template.py
@@ -30,6 +30,7 @@ from agent_starter_pack.cli.utils.remote_template import (
     parse_agent_starter_pack_version_from_lock,
     render_and_merge_makefiles,
 )
+from agent_starter_pack.cli.utils.template import _extract_agent_garden_labels
 
 
 class TestRemoteTemplateSpec:
@@ -1054,10 +1055,6 @@ class TestAgentGardenLabelExtraction:
 
     def test_extract_from_remote_spec_adk_samples(self) -> None:
         """Test extracting labels from remote_spec when is_adk_samples=True."""
-        from agent_starter_pack.cli.utils.remote_template import RemoteTemplateSpec
-
-        # Simulate the logic in template.py
-        agent_garden = True
         remote_spec = RemoteTemplateSpec(
             repo_url="https://github.com/google/adk-samples",
             template_path="python/agents/RAG",
@@ -1065,20 +1062,19 @@ class TestAgentGardenLabelExtraction:
             is_adk_samples=True,
         )
 
-        # Extract labels (mimicking template.py logic)
-        agent_sample_id = None
-        agent_sample_publisher = None
-
-        if agent_garden and remote_spec and remote_spec.is_adk_samples:
-            agent_sample_id = pathlib.Path(remote_spec.template_path).name
-            agent_sample_publisher = "google"
+        agent_sample_id, agent_sample_publisher = _extract_agent_garden_labels(
+            agent_garden=True,
+            remote_spec=remote_spec,
+            remote_template_path=None,
+        )
 
         assert agent_sample_id == "RAG"
         assert agent_sample_publisher == "google"
 
     def test_extract_from_pyproject_toml(self) -> None:
         """Test extracting labels from pyproject.toml fallback."""
-        # Simulate the logic in template.py
+        import sys
+
         remote_template_path = pathlib.Path("/test/template")
 
         pyproject_content = b"""
@@ -1087,42 +1083,33 @@ name = "rag"
 version = "0.1.0"
 """
 
-        agent_sample_id = None
-        agent_sample_publisher = None
-
         # Mock the toml data that would be loaded
         mock_toml_data = {"project": {"name": "rag", "version": "0.1.0"}}
+
+        # Determine which toml library to mock based on Python version
+        if sys.version_info >= (3, 11):
+            toml_module = "tomllib"
+        else:
+            toml_module = "tomli"
 
         with (
             patch("pathlib.Path.exists", return_value=True),
             patch("builtins.open", mock_open(read_data=pyproject_content)),
+            patch(f"{toml_module}.load") as mock_toml_load,
         ):
-            # Manually parse the pyproject content for this test
+            mock_toml_load.return_value = mock_toml_data
 
-            pyproject_path = remote_template_path / "pyproject.toml"
-            if pyproject_path.exists():
-                try:
-                    # Simulate what would happen with real tomllib.load
-                    pyproject_data = mock_toml_data
-
-                    project_name_from_toml = pyproject_data.get("project", {}).get(
-                        "name"
-                    )
-
-                    if project_name_from_toml:
-                        agent_sample_id = project_name_from_toml
-                        agent_sample_publisher = "google"
-                except Exception:
-                    pass
+            agent_sample_id, agent_sample_publisher = _extract_agent_garden_labels(
+                agent_garden=True,
+                remote_spec=None,
+                remote_template_path=remote_template_path,
+            )
 
         assert agent_sample_id == "rag"
         assert agent_sample_publisher == "google"
 
     def test_no_labels_when_agent_garden_false(self) -> None:
         """Test that labels are not set when agent_garden=False."""
-        from agent_starter_pack.cli.utils.remote_template import RemoteTemplateSpec
-
-        agent_garden = False
         remote_spec = RemoteTemplateSpec(
             repo_url="https://github.com/google/adk-samples",
             template_path="python/agents/RAG",
@@ -1130,12 +1117,11 @@ version = "0.1.0"
             is_adk_samples=True,
         )
 
-        agent_sample_id = None
-        agent_sample_publisher = None
-
-        if agent_garden and remote_spec and remote_spec.is_adk_samples:
-            agent_sample_id = pathlib.Path(remote_spec.template_path).name
-            agent_sample_publisher = "google"
+        agent_sample_id, agent_sample_publisher = _extract_agent_garden_labels(
+            agent_garden=False,
+            remote_spec=remote_spec,
+            remote_template_path=None,
+        )
 
         # Labels should remain None when agent_garden=False
         assert agent_sample_id is None
@@ -1145,15 +1131,12 @@ version = "0.1.0"
         """Test that labels remain empty when pyproject.toml doesn't exist."""
         remote_template_path = pathlib.Path("/test/template")
 
-        agent_sample_id = None
-        agent_sample_publisher = None
-
         with patch("pathlib.Path.exists", return_value=False):
-            pyproject_path = remote_template_path / "pyproject.toml"
-            if pyproject_path.exists():
-                # This shouldn't execute
-                agent_sample_id = "should_not_be_set"
-                agent_sample_publisher = "should_not_be_set"
+            agent_sample_id, agent_sample_publisher = _extract_agent_garden_labels(
+                agent_garden=True,
+                remote_spec=None,
+                remote_template_path=remote_template_path,
+            )
 
         assert agent_sample_id is None
         assert agent_sample_publisher is None


### PR DESCRIPTION
## Summary
- Extract Agent Garden label extraction logic into dedicated helper function
- Move `import sys` to module level following Python conventions
- Update tests to call helper function directly with proper mocking

## Problem
The Agent Garden label extraction logic in `process_template` had become complex with the addition of the fallback mechanism for version-locked templates. This made the code:
- Harder to maintain due to nested conditionals and inline logic
- Difficult to test in isolation
- Non-compliant with Python conventions (local `import sys`)
- Prone to test brittleness through implementation duplication

## Solution
Refactored the label extraction logic into `_extract_agent_garden_labels()` helper function with:
- Clear separation of concerns between remote spec and pyproject.toml fallback paths
- Comprehensive documentation explaining the two extraction mechanisms
- Module-level imports following Python best practices
- Tests that verify function behavior rather than duplicating implementation
- Proper mocking strategy for Python version-dependent imports (tomllib/tomli)

This approach ensures the code is more maintainable, testable, and follows established conventions.