### PR TITLE
fix: remove .md extension from CLI nav link

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -63,7 +63,7 @@ export default defineConfig({
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'Remote Templates', link: '/remote-templates/' },
       { text: 'Agents', link: '/agents/overview' },
-      { text: 'CLI', link: '/cli/index.md' },
+      { text: 'CLI', link: '/cli' },
       { text: 'Community', link: '/guide/community-showcase' }
     ],
     sidebar: [


### PR DESCRIPTION
Update CLI navigation link to use clean URL format for consistency with other navigation items and VitePress best practices.

All other nav links use clean URLs without file extensions.

Related to https://github.com/GoogleCloudPlatform/agent-starter-pack/issues/441.