### PR TITLE
fix: correct AlloyDB initial user dependency and Agent Engine bucket reference

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/deployment/terraform/{% if not cookiecutter.is_adk_live %}service.tf{% else %}unused_service.tf{% endif %}
+++ b/agent_starter_pack/deployment_targets/agent_engine/deployment/terraform/{% if not cookiecutter.is_adk_live %}service.tf{% else %}unused_service.tf{% endif %}
@@ -40,7 +40,7 @@ resource "google_vertex_ai_reasoning_engine" "app_staging" {
     deployment_spec {
       env {
         name  = "ARTIFACTS_BUCKET_NAME"
-        value = google_storage_bucket.logs_bucket["staging"].name
+        value = google_storage_bucket.logs_data_bucket[var.staging_project_id].name
       }
     }
 {%- endif %}
@@ -80,7 +80,7 @@ resource "google_vertex_ai_reasoning_engine" "app_prod" {
     deployment_spec {
       env {
         name  = "ARTIFACTS_BUCKET_NAME"
-        value = google_storage_bucket.logs_bucket["prod"].name
+        value = google_storage_bucket.logs_data_bucket[var.prod_project_id].name
       }
     }
 {%- endif %}


### PR DESCRIPTION
## Summary
- Move `random_password` resource before AlloyDB cluster creation
- Update Agent Engine bucket reference from `logs_bucket` to `logs_data_bucket`
- Add proper dependency chain for AlloyDB initial user configuration

## Problem
Terraform deployments failed with two issues:

1. **AlloyDB Initial User**: The `random_password` resource was defined after the `google_alloydb_cluster` resource, but the cluster's `initial_user` block referenced the password. This created an implicit dependency that could cause race conditions or deployment failures.

2. **Agent Engine Bucket Reference**: The Agent Engine service configuration referenced `google_storage_bucket.logs_bucket`, but the actual resource is named `logs_data_bucket`, causing Terraform errors when deploying Agent Engine targets.

## Solution
1. Moved `random_password` resource definition before `google_alloydb_cluster` in all Cloud Run deployment configurations
2. Added explicit dependency in cluster's `depends_on` to ensure proper resource creation order
3. Updated Agent Engine service.tf to reference correct bucket resource name `logs_data_bucket` with project ID key