### PR TITLE
Refactor register-gemini-enterprise to CLI subcommand

### DIFF
--- a/agent_starter_pack/base_template/Makefile
+++ b/agent_starter_pack/base_template/Makefile
@@ -315,5 +315,5 @@ lint:
 # Usage: ID="projects/.../engines/xxx" make register-gemini-enterprise
 # Optional env vars: GEMINI_DISPLAY_NAME, GEMINI_DESCRIPTION, GEMINI_TOOL_DESCRIPTION, AGENT_ENGINE_ID
 register-gemini-enterprise:
-	uvx --from agent-starter-pack agent-starter-pack-register-gemini-enterprise
+	uvx agent-starter-pack@{{ cookiecutter.package_version }} register-gemini-enterprise
 {%- endif %}

--- a/agent_starter_pack/cli/commands/register_gemini_enterprise.py
+++ b/agent_starter_pack/cli/commands/register_gemini_enterprise.py
@@ -371,7 +371,7 @@ def register_agent(
     help="OAuth authorization resource name "
     "(e.g., projects/{project_number}/locations/global/authorizations/{auth_id}).",
 )
-def main(
+def register_gemini_enterprise(
     agent_engine_id: str | None,
     metadata_file: str,
     gemini_enterprise_app_id: str | None,
@@ -420,7 +420,3 @@ def main(
         )
     except Exception as e:
         raise click.ClickException(f"Error during registration: {e}") from e
-
-
-if __name__ == "__main__":
-    main()

--- a/agent_starter_pack/cli/main.py
+++ b/agent_starter_pack/cli/main.py
@@ -21,6 +21,7 @@ from rich.console import Console
 from .commands.create import create
 from .commands.enhance import enhance
 from .commands.list import list_agents
+from .commands.register_gemini_enterprise import register_gemini_enterprise
 from .commands.setup_cicd import setup_cicd
 from .utils import display_update_message
 
@@ -57,6 +58,7 @@ def cli() -> None:
 # Register commands
 cli.add_command(create)
 cli.add_command(enhance)
+cli.add_command(register_gemini_enterprise)
 cli.add_command(setup_cicd)
 cli.add_command(list_agents, name="list")
 

--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/agent_engine_app.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/agent_engine_app.py
@@ -31,7 +31,7 @@ from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.a2a.utils.agent_card_builder import AgentCardBuilder
 from google.adk.apps.app import App
 {%- endif %}
-from google.adk.artifacts import GcsArtifactService
+from google.adk.artifacts import GcsArtifactService, InMemoryArtifactService
 {%- if cookiecutter.is_adk_a2a %}
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
@@ -169,20 +169,18 @@ agent_engine = AgentEngineApp.create(
     artifact_service=(
         GcsArtifactService(bucket_name=artifacts_bucket_name)
         if artifacts_bucket_name
-        else None
+        else InMemoryArtifactService()
     ),
     session_service=InMemorySessionService(),
 )
 {%- else %}
-artifact_service_builder = (
-    lambda: GcsArtifactService(bucket_name=artifacts_bucket_name)
-    if artifacts_bucket_name
-    else None
-)
-
 agent_engine = AgentEngineApp(
     app=adk_app,
-    artifact_service_builder=artifact_service_builder,
+    artifact_service_builder=lambda: GcsArtifactService(
+        bucket_name=artifacts_bucket_name
+    )
+    if artifacts_bucket_name
+    else InMemoryArtifactService(),
 )
 {%- endif -%}
 {% else %}

--- a/docs/cli/register_gemini_enterprise.md
+++ b/docs/cli/register_gemini_enterprise.md
@@ -8,8 +8,11 @@ Register a deployed Agent Engine to Gemini Enterprise, making it available as a 
 # Via Makefile (recommended)
 ID="projects/.../engines/xxx" make register-gemini-enterprise
 
-# Direct command
-uvx --from agent-starter-pack agent-starter-pack-register-gemini-enterprise [OPTIONS]
+# Direct command (installed)
+agent-starter-pack register-gemini-enterprise [OPTIONS]
+
+# Or with uvx (no install required)
+uvx agent-starter-pack@latest register-gemini-enterprise [OPTIONS]
 ```
 
 ## Quick Start
@@ -82,7 +85,7 @@ export GEMINI_ENTERPRISE_APP_ID="projects/.../engines/xxx"
 export GEMINI_DISPLAY_NAME="Product Support Agent"
 export GEMINI_DESCRIPTION="AI agent for product support"
 
-agent-starter-pack-register-gemini-enterprise
+agent-starter-pack register-gemini-enterprise
 ```
 
 ## Troubleshooting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 agent-starter-pack = "agent_starter_pack.cli.main:cli"
-agent-starter-pack-register-gemini-enterprise = "agent_starter_pack.cli.utils.register_gemini_enterprise:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["agent_starter_pack", "llm.txt"]

--- a/tests/cicd/test_gemini_enterprise_registration.py
+++ b/tests/cicd/test_gemini_enterprise_registration.py
@@ -198,7 +198,7 @@ class TestGeminiEnterpriseRegistration:
             # Step 4: Register with Gemini Enterprise
             logger.info("\n🔗 Step 4: Registering with Gemini Enterprise")
             register_result = run_command(
-                ["uv", "run", "agent-starter-pack-register-gemini-enterprise"],
+                ["uv", "run", "agent-starter-pack", "register-gemini-enterprise"],
                 cwd=str(project_path),
                 env={"ID": gemini_app_id},
                 capture_output=True,

--- a/tests/cli/utils/test_register_gemini_enterprise.py
+++ b/tests/cli/utils/test_register_gemini_enterprise.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from agent_starter_pack.cli.utils.register_gemini_enterprise import (
+from agent_starter_pack.cli.commands.register_gemini_enterprise import (
     get_discovery_engine_endpoint,
 )
 

--- a/tests/fixtures/makefile_hashes.json
+++ b/tests/fixtures/makefile_hashes.json
@@ -1,7 +1,7 @@
 {
-  "adk_a2a_agent_engine": "10d818e7fd1966325d1de7a9d7082574c74477a424f472478d1216686d196f5a",
+  "adk_a2a_agent_engine": "08e69c6ecca0515b8c5ebfde58bb785ed1f69f0bf8e2c835dbe9f5ef1c3ffd8e",
   "adk_a2a_cloud_run": "af30ef40c1c84582d9322d48864d2329b2f34efe615e6a873eb1e695cffd24c7",
-  "adk_base_agent_engine_no_data": "c0d407869c19551e534de18b138007ef29e7dcf63a45969caff266361d06be2c",
+  "adk_base_agent_engine_no_data": "78181ba4967c57ce14917384829da889c8673f6d8c8984567e27a4db9b9b0a5c",
   "adk_base_cloud_run_no_data": "b63105d6122d61b85ce3d578de319133afaf1de2f37c56c56665da290e7fe375",
   "adk_live_agent_engine": "0d759388e24fad173bd923b413eadf02af482203fa497b748aeb4f67dd954c48",
   "adk_live_cloud_run": "b6371a9cda3cfb08baac1924b56302047e5d8f144c3992fe032dd58e36fc8c43",

--- a/tests/fixtures/makefile_snapshots/adk_a2a_agent_engine.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_a2a_agent_engine.makefile
@@ -124,4 +124,4 @@ lint:
 # Usage: ID="projects/.../engines/xxx" make register-gemini-enterprise
 # Optional env vars: GEMINI_DISPLAY_NAME, GEMINI_DESCRIPTION, GEMINI_TOOL_DESCRIPTION, AGENT_ENGINE_ID
 register-gemini-enterprise:
-	uvx --from agent-starter-pack agent-starter-pack-register-gemini-enterprise
+	uvx agent-starter-pack@0.20.0 register-gemini-enterprise

--- a/tests/fixtures/makefile_snapshots/adk_base_agent_engine_no_data.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_base_agent_engine_no_data.makefile
@@ -75,4 +75,4 @@ lint:
 # Usage: ID="projects/.../engines/xxx" make register-gemini-enterprise
 # Optional env vars: GEMINI_DISPLAY_NAME, GEMINI_DESCRIPTION, GEMINI_TOOL_DESCRIPTION, AGENT_ENGINE_ID
 register-gemini-enterprise:
-	uvx --from agent-starter-pack agent-starter-pack-register-gemini-enterprise
+	uvx agent-starter-pack@0.20.0 register-gemini-enterprise

--- a/tests/unit/test_makefile_template.py
+++ b/tests/unit/test_makefile_template.py
@@ -49,6 +49,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "What can you help me with?",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "adk_base_agent_engine_no_data": {
         "project_name": "test-adk-base",
@@ -61,6 +62,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "What can you help me with?",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "adk_live_cloud_run": {
         "project_name": "test-adk-live",
@@ -73,6 +75,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "Tell me about your capabilities",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "adk_live_agent_engine": {
         "project_name": "test-adk-live",
@@ -85,6 +88,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "Tell me about your capabilities",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "agentic_rag_cloud_run_vertex_search": {
         "project_name": "test-rag",
@@ -98,6 +102,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "What's in the knowledge base?",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "agentic_rag_cloud_run_vector_search": {
         "project_name": "test-rag",
@@ -111,6 +116,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "What's in the knowledge base?",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "langgraph_cloud_run_no_data": {
         "project_name": "test-langgraph",
@@ -123,6 +129,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "How can you help?",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "agent_with_custom_commands": {
         "project_name": "test-custom",
@@ -155,6 +162,7 @@ TEST_CONFIGURATIONS = {
                 },
             }
         },
+        "package_version": "0.20.0",
     },
     "agent_with_agent_garden": {
         "project_name": "test-garden",
@@ -169,6 +177,7 @@ TEST_CONFIGURATIONS = {
         "agent_sample_publisher": "google",
         "example_question": "Agent garden question",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "adk_a2a_cloud_run": {
         "project_name": "test-a2a",
@@ -181,6 +190,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "What can you help me with?",
         "settings": {},
+        "package_version": "0.20.0",
     },
     "adk_a2a_agent_engine": {
         "project_name": "test-a2a",
@@ -193,6 +203,7 @@ TEST_CONFIGURATIONS = {
         "agent_garden": False,
         "example_question": "What can you help me with?",
         "settings": {},
+        "package_version": "0.20.0",
     },
 }
 


### PR DESCRIPTION
## Summary
- Convert `register-gemini-enterprise` from standalone script to CLI subcommand
- Update command invocation to use version pinning: `uvx agent-starter-pack@{{ cookiecutter.package_version }}`
- Improve command discoverability via `--help` output

## Problem
The `register-gemini-enterprise` command was implemented as a standalone script (`agent-starter-pack-register-gemini-enterprise`) rather than a proper CLI subcommand like `create`, `enhance`, and `setup-cicd`. This created inconsistency in the CLI interface and made the command harder to discover.

## Solution
Refactored the command to follow the established CLI pattern:

**File Structure:**
- Moved `cli/utils/register_gemini_enterprise.py` → `cli/commands/register_gemini_enterprise.py`
- Renamed `main()` → `register_gemini_enterprise()` to match command naming convention
- Registered command in `cli/main.py`

**Updated Invocations:**
- Old: `agent-starter-pack-register-gemini-enterprise`
- New: `agent-starter-pack register-gemini-enterprise`
- Makefiles now use: `uvx agent-starter-pack@{{ cookiecutter.package_version }} register-gemini-enterprise`

**Benefits:**
- ✅ Consistent command structure across all CLI operations
- ✅ Shows in `agent-starter-pack --help` for better discoverability
- ✅ Single CLI entry point (no separate script)
- ✅ Version pinning in generated projects via cookiecutter template variable

## Testing
- ✅ Unit tests pass (`tests/cli/utils/test_register_gemini_enterprise.py`)
- ✅ Command appears in `--help` output
- ✅ Command help works: `agent-starter-pack register-gemini-enterprise --help`
- ✅ Updated Makefile snapshots for test fixtures