### PR TITLE
Fix: Restrict app injection to agent_engine deployment only

### DIFF
--- a/tests/cli/commands/test_enhance.py
+++ b/tests/cli/commands/test_enhance.py
@@ -563,12 +563,13 @@ root_agent = Agent(
             # Verify agent.py was modified to add app object (backward compatibility)
             preserved_agent_content = agent_file.read_text()
             expected_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
 
 root_agent = Agent(
     name="test_agent",
     model="gemini-2.0-flash-001",
 )
+
+from google.adk.apps.app import App
 
 app = App(root_agent=root_agent, name="app")
 """
@@ -629,20 +630,11 @@ app = App(root_agent=root_agent, name="app")
                     f"Expected Cloud Run file {cloud_run_file} was not created"
                 )
 
-            # Verify agent.py was modified to add app object (backward compatibility)
+            # Verify agent.py was NOT modified for cloud_run (no injection for cloud_run)
             preserved_agent_content = agent_file.read_text()
-            expected_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
-
-root_agent = Agent(
-    name="test_agent",
-    model="gemini-2.0-flash-001",
-)
-
-app = App(root_agent=root_agent, name="app")
-"""
-            assert preserved_agent_content == expected_content, (
-                f"agent.py was not modified correctly! Expected:\n{expected_content}\n\nGot:\n{preserved_agent_content}"
+            # For cloud_run, agent.py should remain unchanged
+            assert preserved_agent_content == agent_content, (
+                f"agent.py should not be modified for cloud_run! Expected:\n{agent_content}\n\nGot:\n{preserved_agent_content}"
             )
 
     def test_data_ingestion_populates_files(self, tmp_path: pathlib.Path) -> None:
@@ -710,12 +702,13 @@ root_agent = Agent(
             # Verify agent.py was modified to add app object (backward compatibility)
             preserved_agent_content = agent_file.read_text()
             expected_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
 
 root_agent = Agent(
     name="test_agent",
     model="gemini-2.0-flash-001",
 )
+
+from google.adk.apps.app import App
 
 app = App(root_agent=root_agent, name="app")
 """


### PR DESCRIPTION
## Summary
- Restrict automatic app object injection to agent_engine deployment only
- Simplify injection logic by placing import and app object at end of file
- Update tests to reflect new behavior

## Problem
App injection was occurring for all ADK remote templates regardless of deployment target, causing:
- Syntax errors in some cases due to complex import placement logic
- Unnecessary modifications for Cloud Run deployments where app object isn't needed
- Inconsistent file modifications

## Solution
1. Modified injection condition to only run for `deployment_target == "agent_engine"`
2. Simplified injection logic: both import and app instantiation now append to end of file
3. Updated test expectations:
   - agent_engine tests expect injection with import at bottom
   - cloud_run tests expect no modification

This resolves syntax errors and ensures app injection only occurs where it's actually needed.