### PR TITLE
Show Console Playground URL for ADK base samples

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -94,20 +94,13 @@ def print_deployment_success(
     resource_name_parts = remote_agent.api_resource.name.split("/")
     agent_engine_id = resource_name_parts[-1]
     project_number = resource_name_parts[1]
-    console_url = f"https://console.cloud.google.com/vertex-ai/agents/locations/{location}/agent-engines/{agent_engine_id}?project={project}"
 
-{%- if cookiecutter.is_adk %}
 {%- if cookiecutter.is_adk_live %}
     print("\n✅ Deployment successful! Run your agent with: `make playground-remote`")
 {%- elif cookiecutter.is_adk_a2a %}
     print(
         "\n✅ Deployment successful! Test your agent: notebooks/adk_a2a_app_testing.ipynb"
     )
-{%- else %}
-    print(
-        "\n✅ Deployment successful! Test your agent: notebooks/adk_app_testing.ipynb"
-    )
-{%- endif %}
 {%- else %}
     print("\n✅ Deployment successful!")
 {%- endif %}
@@ -119,7 +112,13 @@ def print_deployment_success(
             f"service-{project_number}@gcp-sa-aiplatform-re.iam.gserviceaccount.com"
         )
         print(f"Service Account: {default_sa}")
+{%- if cookiecutter.is_adk and not cookiecutter.is_adk_live and not cookiecutter.is_adk_a2a %}
+    playground_url = f"https://console.cloud.google.com/vertex-ai/agents/locations/{location}/agent-engines/{agent_engine_id}/playground?project={project}"
+    print(f"\n📊 Open Console Playground: {playground_url}\n")
+{%- else %}
+    console_url = f"https://console.cloud.google.com/vertex-ai/agents/locations/{location}/agent-engines/{agent_engine_id}?project={project}"
     print(f"\n📊 View in Console: {console_url}\n")
+{%- endif %}
 
 
 @click.command()


### PR DESCRIPTION
## Summary
- Replace notebook reference with Console Playground URL for ADK base deployments
- Optimize Jinja2 conditionals to reduce redundancy
- Create URLs only when needed (playground for ADK base, console for others)

## Changes
For ADK base samples (excluding adk_live and adk_a2a), the deployment success message now displays:
```
✅ Deployment successful!
Service Account: service-123@...

📊 Open Console Playground: https://console.cloud.google.com/.../playground?project=...
```

This provides a more actionable next step by linking directly to where users can test their deployed agent, rather than referencing a notebook.