### PR TITLE
feat: enable A2A Inspector for Agent Engine deployments

### DIFF
--- a/agent_starter_pack/base_template/Makefile
+++ b/agent_starter_pack/base_template/Makefile
@@ -152,9 +152,7 @@ playground-dev:
 	@echo "Starting frontend dev server..."
 	$(MAKE) ui
 {%- endif %}
-{%- if cookiecutter.is_adk_a2a and cookiecutter.deployment_target == 'cloud_run' %}
-# TODO: Remove 'and cookiecutter.deployment_target == 'cloud_run'' condition
-# when a2a-inspector adds HTTP-JSON transport support (currently JSON-RPC 2.0 only)
+{%- if cookiecutter.is_adk_a2a %}
 
 # ==============================================================================
 # A2A Protocol Inspector
@@ -196,7 +194,7 @@ setup-inspector-if-needed:
 		echo "" && \
 		mkdir -p tools && \
 		git clone --quiet https://github.com/a2aproject/a2a-inspector.git tools/a2a-inspector && \
-		(cd tools/a2a-inspector && git -c advice.detachedHead=false checkout --quiet 24086e48b244b503dc6ccc976c9485bd6ec04ec8) && \
+		(cd tools/a2a-inspector && git -c advice.detachedHead=false checkout --quiet c15ae469d6dcb26f72ffe08a46dd561974af764b) && \
 		echo "📥 Installing Python dependencies..." && \
 		(cd tools/a2a-inspector && uv sync --quiet) && \
 		echo "📥 Installing Node.js dependencies..." && \

--- a/agent_starter_pack/base_template/README.md
+++ b/agent_starter_pack/base_template/README.md
@@ -75,8 +75,7 @@ make install && make playground
 | `make register-gemini-enterprise` | Register deployed agent to Gemini Enterprise ([docs](https://googlecloudplatform.github.io/agent-starter-pack/cli/register_gemini_enterprise.html)) |
 {%- endif -%}
 {%- endif -%}
-{# TODO: Remove 'and cookiecutter.deployment_target == 'cloud_run'' when inspector adds HTTP-JSON support #}
-{%- if cookiecutter.is_adk_a2a and cookiecutter.deployment_target == 'cloud_run' %}
+{%- if cookiecutter.is_adk_a2a %}
 | `make inspector`     | Launch A2A Protocol Inspector to test your agent implementation                             |
 {%- endif %}
 | `make test`          | Run unit and integration tests                                                              |
@@ -88,10 +87,7 @@ make install && make playground
 
 For full command options and usage, refer to the [Makefile](Makefile).
 
-{# TODO: Remove 'and cookiecutter.deployment_target == 'cloud_run'' condition #}
-{# when a2a-inspector adds HTTP-JSON transport support (currently JSON-RPC 2.0 only) #}
 {%- if cookiecutter.is_adk_a2a %}
-{%- if cookiecutter.deployment_target == 'cloud_run' %}
 
 ## Using the A2A Inspector
 
@@ -101,9 +97,10 @@ The [A2A Inspector](https://github.com/a2aproject/a2a-inspector) provides the fo
 - 🔍 View agent card and capabilities
 - ✅ Validate A2A specification compliance
 - 💬 Test communication with live chat interface
-- 🐛 Debug with raw JSON-RPC 2.0 message console
+- 🐛 Debug with the raw message console
 
 ### Local Testing
+{%- if cookiecutter.deployment_target == 'cloud_run' %}
 
 1. Start your agent:
    ```bash
@@ -116,6 +113,10 @@ The [A2A Inspector](https://github.com/a2aproject/a2a-inspector) provides the fo
    ```
 
 3. Open http://localhost:5001 and connect to `http://localhost:8000`
+{%- else %}
+
+> **Note:** For Agent Engine deployments, local testing with A2A endpoints requires deployment first, as `make playground` uses the ADK web interface. For local development, use `make playground`. To test A2A protocol compliance, follow the Remote Testing instructions below.
+{%- endif %}
 
 ### Remote Testing
 
@@ -149,7 +150,6 @@ The [A2A Inspector](https://github.com/a2aproject/a2a-inspector) provides the fo
      https://us-central1-aiplatform.googleapis.com/v1beta1/projects/{PROJECT_ID}/locations/{REGION}/reasoningEngines/{ENGINE_ID}/a2a/v1/card
      ```
      Find your `PROJECT_ID`, `REGION`, and `ENGINE_ID` in the `latest_deployment_metadata.json` file created after deployment.
-{%- endif %}
 {%- endif %}
 {%- endif %}
 

--- a/tests/fixtures/makefile_hashes.json
+++ b/tests/fixtures/makefile_hashes.json
@@ -1,6 +1,6 @@
 {
-  "adk_a2a_agent_engine": "55c02cea17b1514a737a296ee379a19bb11452f0efe7eb9c329058cff34b7482",
-  "adk_a2a_cloud_run": "c66601bc408d0cd3eb1e1e424126e8561612cebb77fa8020dc4b33753b88e834",
+  "adk_a2a_agent_engine": "10d818e7fd1966325d1de7a9d7082574c74477a424f472478d1216686d196f5a",
+  "adk_a2a_cloud_run": "af30ef40c1c84582d9322d48864d2329b2f34efe615e6a873eb1e695cffd24c7",
   "adk_base_agent_engine_no_data": "c0d407869c19551e534de18b138007ef29e7dcf63a45969caff266361d06be2c",
   "adk_base_cloud_run_no_data": "b63105d6122d61b85ce3d578de319133afaf1de2f37c56c56665da290e7fe375",
   "adk_live_agent_engine": "0d759388e24fad173bd923b413eadf02af482203fa497b748aeb4f67dd954c48",

--- a/tests/fixtures/makefile_snapshots/adk_a2a_agent_engine.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_a2a_agent_engine.makefile
@@ -23,6 +23,55 @@ playground:
 	uv run adk web . --port 8501 --reload_agents
 
 # ==============================================================================
+# A2A Protocol Inspector
+# ==============================================================================
+
+# Launch A2A Protocol Inspector to test your agent implementation
+inspector: setup-inspector-if-needed build-inspector-if-needed
+	@echo "==============================================================================="
+	@echo "| 🔍 A2A Protocol Inspector                                                  |"
+	@echo "==============================================================================="
+	@echo "| 🌐 Inspector UI: http://localhost:5001                                     |"
+	@echo "|                                                                             |"
+	@echo "| 💡 Testing Remote Deployment:                                               |"
+	@echo "|    Connect to your deployed Agent Engine URL                               |"
+	@echo "|    🔐 See README for authentication setup                                  |"
+	@echo "|                                                                             |"
+	@echo "| ℹ️  Note: Local testing requires deploying to Agent Engine first.          |"
+	@echo "|    Local 'make playground' uses ADK web interface (not A2A endpoints)      |"
+	@echo "==============================================================================="
+	@echo ""
+	cd tools/a2a-inspector/backend && uv run app.py
+
+# Internal: Setup inspector if not already present (runs once)
+# TODO: Update to --branch v1.0.0 when a2a-inspector publishes releases
+setup-inspector-if-needed:
+	@if [ ! -d "tools/a2a-inspector" ]; then \
+		echo "" && \
+		echo "📦 First-time setup: Installing A2A Inspector..." && \
+		echo "" && \
+		mkdir -p tools && \
+		git clone --quiet https://github.com/a2aproject/a2a-inspector.git tools/a2a-inspector && \
+		(cd tools/a2a-inspector && git -c advice.detachedHead=false checkout --quiet c15ae469d6dcb26f72ffe08a46dd561974af764b) && \
+		echo "📥 Installing Python dependencies..." && \
+		(cd tools/a2a-inspector && uv sync --quiet) && \
+		echo "📥 Installing Node.js dependencies..." && \
+		(cd tools/a2a-inspector/frontend && npm install --silent) && \
+		echo "🔨 Building frontend..." && \
+		(cd tools/a2a-inspector/frontend && npm run build --silent) && \
+		echo "" && \
+		echo "✅ A2A Inspector setup complete!" && \
+		echo ""; \
+	fi
+
+# Internal: Build inspector frontend if needed
+build-inspector-if-needed:
+	@if [ ! -f "tools/a2a-inspector/frontend/public/script.js" ]; then \
+		echo "🔨 Building inspector frontend..."; \
+		cd tools/a2a-inspector/frontend && npm run build; \
+	fi
+
+# ==============================================================================
 # Backend Deployment Targets
 # ==============================================================================
 

--- a/tests/fixtures/makefile_snapshots/adk_a2a_cloud_run.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_a2a_cloud_run.makefile
@@ -29,8 +29,6 @@ playground:
 # Launch local development server with hot-reload
 local-backend:
 	uv run uvicorn test_a2a.fast_api_app:app --host localhost --port 8000 --reload
-# TODO: Remove 'and cookiecutter.deployment_target == 'cloud_run'' condition
-# when a2a-inspector adds HTTP-JSON transport support (currently JSON-RPC 2.0 only)
 
 # ==============================================================================
 # A2A Protocol Inspector
@@ -62,7 +60,7 @@ setup-inspector-if-needed:
 		echo "" && \
 		mkdir -p tools && \
 		git clone --quiet https://github.com/a2aproject/a2a-inspector.git tools/a2a-inspector && \
-		(cd tools/a2a-inspector && git -c advice.detachedHead=false checkout --quiet 24086e48b244b503dc6ccc976c9485bd6ec04ec8) && \
+		(cd tools/a2a-inspector && git -c advice.detachedHead=false checkout --quiet c15ae469d6dcb26f72ffe08a46dd561974af764b) && \
 		echo "📥 Installing Python dependencies..." && \
 		(cd tools/a2a-inspector && uv sync --quiet) && \
 		echo "📥 Installing Node.js dependencies..." && \


### PR DESCRIPTION
Update A2A Inspector integration to support both Cloud Run and Agent Engine deployment targets with latest inspector commit.

  - Update inspector git hash to latest version
  - Remove cloud_run deployment target restriction from inspector commands
  - Add conditional documentation for Agent Engine local testing limitations
  - Update Makefile to enable inspector for all A2A-enabled deployments

Related to https://github.com/GoogleCloudPlatform/agent-starter-pack/issues/135