### PR TITLE
Fix scheduled cleanup to use new E2E project IDs

### DIFF
--- a/.cloudbuild/scheduled-cleanup.yaml
+++ b/.cloudbuild/scheduled-cleanup.yaml
@@ -17,6 +17,10 @@ steps:
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"
     id: force-cleanup
     entrypoint: /bin/bash
+    env:
+      - 'PROJECT_IDS=${_PROJECT_IDS}'
+      - 'E2E_PROJECT_IDS=${_E2E_PROJECT_IDS}'
+      - 'CICD_PROJECT_ID=${_CICD_PROJECT_ID}'
     args:
       - "-c"
       - |
@@ -28,3 +32,8 @@ timeout: 18000s  # 5 hour timeout for cleanup operations
 logsBucket: gs://${PROJECT_ID}-logs-data/build-logs
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+
+substitutions:
+  _PROJECT_IDS: 'asp-starter-dev,asp-starter-prod,asp-starter-staging'
+  _E2E_PROJECT_IDS: 'asp-starter-dev,asp-starter-prod,asp-starter-staging'
+  _CICD_PROJECT_ID: 'asp-starter-dev'

--- a/tests/cicd/scripts/force-cleanup.sh
+++ b/tests/cicd/scripts/force-cleanup.sh
@@ -14,9 +14,10 @@ NC='\033[0m' # No Color
 echo -e "${GREEN}🚀 Starting comprehensive cleanup...${NC}"
 
 # Project configuration
-export PROJECT_IDS="agent-starter-pack-e2e-dev,agent-starter-pack-e2e-st,agent-starter-pack-e2e-pr,asp-starter-dev,asp-starter-prod,asp-starter-staging"
-export E2E_PROJECT_IDS="agent-starter-pack-e2e-dev,agent-starter-pack-e2e-st,agent-starter-pack-e2e-pr,asp-starter-dev,asp-starter-prod,asp-starter-staging"
-export CICD_PROJECT_ID="agent-starter-pack-e2e-dev"
+# Use environment variables if set, otherwise use defaults
+export PROJECT_IDS="${PROJECT_IDS:-asp-starter-dev,asp-starter-prod,asp-starter-staging}"
+export E2E_PROJECT_IDS="${E2E_PROJECT_IDS:-asp-starter-dev,asp-starter-prod,asp-starter-staging}"
+export CICD_PROJECT_ID="${CICD_PROJECT_ID:-asp-starter-dev}"
 
 echo -e "${YELLOW}📋 Target projects: ${PROJECT_IDS}${NC}"
 echo ""


### PR DESCRIPTION
## Summary
- Update scheduled cleanup to use new asp-starter-* project IDs
- Configure project IDs via Cloud Build substitution variables
- Remove references to old agent-starter-pack-e2e-* projects

## Problem
Scheduled cleanup was failing with permission errors attempting to access old E2E projects (agent-starter-pack-e2e-dev/st/pr) that no longer exist or have restricted access.

## Solution
Updated `.cloudbuild/scheduled-cleanup.yaml` to define project IDs via substitution variables and modified `force-cleanup.sh` to use environment variables with fallback defaults, targeting only the current asp-starter-* projects.