### PR TITLE
Fix project IDs in scheduled cleanup

### DIFF
--- a/.cloudbuild/scheduled-cleanup.yaml
+++ b/.cloudbuild/scheduled-cleanup.yaml
@@ -34,6 +34,6 @@ options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
 
 substitutions:
-  _PROJECT_IDS: 'asp-starter-dev,asp-starter-prod,asp-starter-staging'
-  _E2E_PROJECT_IDS: 'asp-starter-dev,asp-starter-prod,asp-starter-staging'
-  _CICD_PROJECT_ID: 'asp-starter-dev'
+  _PROJECT_IDS: 'asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg'
+  _E2E_PROJECT_IDS: 'asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg'
+  _CICD_PROJECT_ID: 'asp-e2e-cicd'

--- a/tests/cicd/scripts/force-cleanup.sh
+++ b/tests/cicd/scripts/force-cleanup.sh
@@ -15,9 +15,9 @@ echo -e "${GREEN}🚀 Starting comprehensive cleanup...${NC}"
 
 # Project configuration
 # Use environment variables if set, otherwise use defaults
-export PROJECT_IDS="${PROJECT_IDS:-asp-starter-dev,asp-starter-prod,asp-starter-staging}"
-export E2E_PROJECT_IDS="${E2E_PROJECT_IDS:-asp-starter-dev,asp-starter-prod,asp-starter-staging}"
-export CICD_PROJECT_ID="${CICD_PROJECT_ID:-asp-starter-dev}"
+export PROJECT_IDS="${PROJECT_IDS:-asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg}"
+export E2E_PROJECT_IDS="${E2E_PROJECT_IDS:-asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg}"
+export CICD_PROJECT_ID="${CICD_PROJECT_ID:-asp-e2e-cicd}"
 
 echo -e "${YELLOW}📋 Target projects: ${PROJECT_IDS}${NC}"
 echo ""


### PR DESCRIPTION
## Summary
- Update project IDs to match actual GCP projects (asp-e2e-* and asp-test-*)
- Align with Terraform variable configuration

## Problem
PR #504 was merged with placeholder project IDs (asp-starter-*) that don't correspond to actual GCP projects, causing scheduled cleanup to fail.

## Solution
Updated both the Cloud Build config and shell script defaults to use the correct project IDs that match the Terraform `cleanup_project_ids` variable.