### PR TITLE
fix: add missing feedback_logs_filter variable to main Terraform config

### DIFF
--- a/agent_starter_pack/base_template/deployment/terraform/variables.tf
+++ b/agent_starter_pack/base_template/deployment/terraform/variables.tf
@@ -170,6 +170,12 @@ variable "repository_owner" {
   description = "Owner of the Git repository - username or organization"
   type        = string
 }
+
+variable "feedback_logs_filter" {
+  type        = string
+  description = "Log Sink filter for capturing feedback data. Captures logs where the `log_type` field is `feedback`."
+  default     = "jsonPayload.log_type=\"feedback\" jsonPayload.service_name=\"{{cookiecutter.project_name}}\""
+}
 {% if cookiecutter.cicd_runner == "github_actions" %}
 
 


### PR DESCRIPTION
Add feedback_logs_filter variable declaration to the main variables.tf file. This variable is referenced by the feedback logs sink in telemetry.tf but was only declared in the dev-specific variables.tf, causing Terraform validation errors in multi-environment deployments.

The variable was already present in dev/variables.tf but missing from the root-level configuration used for staging/prod environments.