### PR TITLE
Refactor: Use substitution variable for secrets project ID

### DIFF
--- a/.cloudbuild/cd/test_e2e.yaml
+++ b/.cloudbuild/cd/test_e2e.yaml
@@ -34,9 +34,9 @@ steps:
     
 availableSecrets:
   secretManager:
-  - versionName: projects/asp-e2e-vars/secrets/github-pat/versions/latest
+  - versionName: projects/${_SECRETS_PROJECT_ID}/secrets/github-pat/versions/latest
     env: 'GITHUB_PAT'
-  - versionName: projects/$PROJECT_ID/secrets/github-app-installation-id/versions/latest
+  - versionName: projects/${_SECRETS_PROJECT_ID}/secrets/github-app-installation-id/versions/latest
     env: 'GITHUB_APP_INSTALLATION_ID'
 logsBucket: gs://${PROJECT_ID}-logs-data/build-logs
 options:
@@ -49,3 +49,5 @@ options:
     - "E2E_CICD_PROJECT=${PROJECT_ID}"
     - "RUN_E2E_TESTS=1"
 timeout: 43200s
+substitutions:
+  _SECRETS_PROJECT_ID: 'asp-e2e-vars'

--- a/.cloudbuild/terraform/build_triggers.tf
+++ b/.cloudbuild/terraform/build_triggers.tf
@@ -365,9 +365,10 @@ resource "google_cloudbuild_trigger" "main_e2e_deployment_test" {
 
   substitutions = {
     _TEST_AGENT_COMBINATION = each.value.value
-    _E2E_DEV_PROJECT     = var.e2e_test_project_mapping.dev
-    _E2E_STAGING_PROJECT = var.e2e_test_project_mapping.staging
-    _E2E_PROD_PROJECT    = var.e2e_test_project_mapping.prod
+    _E2E_DEV_PROJECT        = var.e2e_test_project_mapping.dev
+    _E2E_STAGING_PROJECT    = var.e2e_test_project_mapping.staging
+    _E2E_PROD_PROJECT       = var.e2e_test_project_mapping.prod
+    _SECRETS_PROJECT_ID     = "asp-e2e-vars"
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded secrets project ID with substitution variable
- Improve consistency across secret references
- Add _SECRETS_PROJECT_ID to Terraform trigger configuration

## Problem
The E2E test configuration hardcoded the project ID `asp-e2e-vars` for the GitHub PAT secret while using the dynamic `$PROJECT_ID` for the installation ID secret. This inconsistency reduces flexibility and makes it harder to understand which project stores which secrets.

Hardcoding project IDs in YAML files also makes the configuration less maintainable when values need to change.

## Solution
Introduced a `_SECRETS_PROJECT_ID` substitution variable to explicitly define the centralized secrets project. Both secret references now use this variable for consistency.

The substitution is defined both in the YAML file (as a default) and passed from Terraform, following the same pattern used for E2E project variables like `_E2E_DEV_PROJECT`.

This makes the configuration more explicit, easier to maintain, and follows Cloud Build best practices for parameterization.