### PR TITLE
Fix duplicate feedback_logs_filter variable declaration

### DIFF
--- a/agent_starter_pack/base_template/deployment/terraform/variables.tf
+++ b/agent_starter_pack/base_template/deployment/terraform/variables.tf
@@ -173,11 +173,6 @@ variable "repository_owner" {
   type        = string
 }
 
-variable "feedback_logs_filter" {
-  type        = string
-  description = "Log Sink filter for capturing feedback data. Captures logs where the `log_type` field is `feedback`."
-  default     = "jsonPayload.log_type=\"feedback\" jsonPayload.service_name=\"{{cookiecutter.project_name}}\""
-}
 {% if cookiecutter.cicd_runner == "github_actions" %}
 
 
@@ -212,12 +207,12 @@ variable "create_repository" {
   default     = false
 }
 {% endif %}
-
 {% if cookiecutter.is_adk %}
+
 variable "feedback_logs_filter" {
-  description = "Filter for feedback logs"
   type        = string
-  default     = "jsonPayload.feedback_score > 0 OR jsonPayload.feedback_score < 0"
+  description = "Log Sink filter for capturing feedback data. Captures logs where the `log_type` field is `feedback`."
+  default     = "jsonPayload.log_type=\"feedback\" jsonPayload.service_name=\"{{cookiecutter.project_name}}\""
 }
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Remove duplicate `feedback_logs_filter` variable declaration in Terraform variables.tf
- Make variable conditional on `is_adk` flag to match actual usage

## Problem
E2E tests failed during Terraform initialization for ADK agents:
```
Error: Duplicate variable declaration

  on variables.tf line 130:
 130: variable "feedback_logs_filter" {

A variable named "feedback_logs_filter" was already declared at
variables.tf:97,1-32. Variable names must be unique within a module.
```

The variable was declared twice:
- Line 176: Unconditional declaration
- Line 217: Inside `{% if cookiecutter.is_adk %}` block

When `is_adk` is true, both declarations existed, causing the error.

## Solution
Consolidated to a single conditional declaration wrapped in `{% if cookiecutter.is_adk %}`. The variable is now only defined when ADK agents are used, matching when the `telemetry.tf` file (which uses this variable) is actually deployed. For non-ADK agents, the variable is not needed since telemetry infrastructure is not created.