### PR TITLE
Fix Cloud SQL dependencies in Cloud Run Terraform

### DIFF
--- a/agent_starter_pack/deployment_targets/cloud_run/deployment/terraform/dev/service.tf
+++ b/agent_starter_pack/deployment_targets/cloud_run/deployment/terraform/dev/service.tf
@@ -233,5 +233,11 @@ resource "google_cloud_run_v2_service" "app" {
   }
 
   # Make dependencies conditional to avoid errors.
-  depends_on = [resource.google_project_service.services]
+  depends_on = [
+    resource.google_project_service.services,
+{%- if cookiecutter.is_adk and cookiecutter.session_type == "cloud_sql" %}
+    google_sql_user.db_user,
+    google_secret_manager_secret_version.db_password,
+{%- endif %}
+  ]
 }

--- a/agent_starter_pack/deployment_targets/cloud_run/deployment/terraform/service.tf
+++ b/agent_starter_pack/deployment_targets/cloud_run/deployment/terraform/service.tf
@@ -252,8 +252,10 @@ resource "google_cloud_run_v2_service" "app_staging" {
   # Make dependencies conditional to avoid errors.
   depends_on = [
     google_project_service.deploy_project_services,
+{%- if cookiecutter.is_adk and cookiecutter.session_type == "cloud_sql" %}
     google_sql_user.db_user,
-    google_secret_manager_secret_version.db_password
+    google_secret_manager_secret_version.db_password,
+{%- endif %}
   ]
 }
 
@@ -407,7 +409,9 @@ resource "google_cloud_run_v2_service" "app_prod" {
   # Make dependencies conditional to avoid errors.
   depends_on = [
     google_project_service.deploy_project_services,
+{%- if cookiecutter.is_adk and cookiecutter.session_type == "cloud_sql" %}
     google_sql_user.db_user,
-    google_secret_manager_secret_version.db_password
+    google_secret_manager_secret_version.db_password,
+{%- endif %}
   ]
 }


### PR DESCRIPTION
## Summary
- Wrapped Cloud SQL resource dependencies in Jinja conditionals
- Fixed Terraform validation errors for non-Cloud SQL Cloud Run deployments

## Problem
E2E tests failed when creating Cloud Run projects with `in_memory` session type:
```
Error: Reference to undeclared resource
A managed resource "google_sql_user" "db_user" has not been declared
```

The Cloud Run service `depends_on` blocks unconditionally referenced Cloud SQL resources that only exist when `session_type == "cloud_sql"`.

## Solution
Added conditional Jinja blocks around Cloud SQL dependencies in both staging/prod and dev service configurations. Dependencies are now only included when `cookiecutter.is_adk and cookiecutter.session_type == "cloud_sql"`.