### PR TITLE
Add Cloud SQL Admin API to required services for ADK Cloud SQL sessions

### DIFF
--- a/agent_starter_pack/base_template/deployment/terraform/locals.tf
+++ b/agent_starter_pack/base_template/deployment/terraform/locals.tf
@@ -20,7 +20,10 @@ locals {
     "serviceusage.googleapis.com",
     "bigquery.googleapis.com",
     "cloudresourcemanager.googleapis.com",
-    "cloudtrace.googleapis.com"
+    "cloudtrace.googleapis.com",
+{%- if cookiecutter.is_adk and cookiecutter.session_type == "cloud_sql" %}
+    "sqladmin.googleapis.com",
+{%- endif %}
   ]
 
   deploy_project_services = [


### PR DESCRIPTION
## Summary
- Add `sqladmin.googleapis.com` to bootstrap services for ADK Cloud SQL configurations

## Problem
When using ADK with Cloud SQL session type, Terraform fails to create Cloud SQL resources during deployment due to missing API enablement. The Cloud SQL Admin API needs to be enabled in the bootstrap phase before Terraform attempts to create database instances.

## Solution
Added conditional inclusion of `sqladmin.googleapis.com` in the `bootstrap_project_services` list when `cookiecutter.is_adk` and `cookiecutter.session_type == "cloud_sql"` are true. This ensures the API is enabled early in the project setup process.