### PR TITLE
Fix identity token retrieval in Cloud Build for Gemini Enterprise registration

### DIFF
--- a/.cloudbuild/cd/test_gemini_enterprise.yaml
+++ b/.cloudbuild/cd/test_gemini_enterprise.yaml
@@ -31,6 +31,15 @@ steps:
       - |
         gcloud config set project ${_E2E_DEV_PROJECT}
 
+  # Fetch identity token for Cloud Run authentication
+  - name: gcr.io/cloud-builders/gcloud
+    id: fetch-id-token
+    entrypoint: /bin/bash
+    args:
+      - "-c"
+      - |
+        gcloud auth print-identity-token -q > /workspace/id_token.txt
+
   # Run Gemini Enterprise registration test
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"
     id: gemini-enterprise-test
@@ -38,6 +47,7 @@ steps:
     args:
       - "-c"
       - |
+        export ID_TOKEN=$(cat /workspace/id_token.txt)
         uv run pytest tests/cicd/test_gemini_enterprise_registration.py -v
     secretEnv: ['GEMINI_ENTERPRISE_APP_ID']
 

--- a/.cloudbuild/terraform/build_triggers.tf
+++ b/.cloudbuild/terraform/build_triggers.tf
@@ -22,6 +22,13 @@ locals {
     "**/Makefile",
   ]
 
+  # Gemini Enterprise related files - these have their own dedicated trigger
+  gemini_enterprise_files = [
+    "agent_starter_pack/cli/commands/register_gemini_enterprise.py",
+    "tests/cicd/test_gemini_enterprise_registration.py",
+    ".cloudbuild/cd/test_gemini_enterprise.yaml",
+  ]
+
   common_included_files = [
     "agent_starter_pack/agents/**",
     "agent_starter_pack/cli/**",
@@ -359,7 +366,7 @@ resource "google_cloudbuild_trigger" "main_e2e_deployment_test" {
 
   filename       = ".cloudbuild/cd/test_e2e.yaml"
   included_files = local.e2e_agent_deployment_included_files[each.key]
-  ignored_files  = local.common_ignored_files
+  ignored_files  = concat(local.common_ignored_files, local.gemini_enterprise_files)
   include_build_logs = "INCLUDE_BUILD_LOGS_UNSPECIFIED"
 
   substitutions = {

--- a/agent_starter_pack/cli/commands/register_gemini_enterprise.py
+++ b/agent_starter_pack/cli/commands/register_gemini_enterprise.py
@@ -299,12 +299,21 @@ def get_access_token() -> str:
 def get_identity_token() -> str:
     """Get Google Cloud identity token.
 
+    First checks for ID_TOKEN environment variable (useful in CI/CD environments
+    like Cloud Build where the token is fetched in a separate step).
+    Falls back to gcloud CLI.
+
     Returns:
         Identity token string
 
     Raises:
         RuntimeError: If authentication fails
     """
+    # Check for pre-fetched token in environment variable (e.g., from Cloud Build)
+    env_token = os.getenv("ID_TOKEN", "").strip()
+    if env_token:
+        return env_token
+
     try:
         result = subprocess.run(
             ["gcloud", "auth", "print-identity-token"],


### PR DESCRIPTION
## Summary
- Add `ID_TOKEN` env var support in `get_identity_token()` for Cloud Build environments
- Add `fetch-id-token` step in test pipeline using gcloud container
- Exclude Gemini Enterprise files from E2E deployment triggers

## Problem
The Gemini Enterprise A2A registration test was failing in Cloud Build because `gcloud auth print-identity-token` doesn't work with metadata credentials in Python containers:

```
Error getting identity token: ERROR: (gcloud.auth.print-identity-token) No 
identity token can be obtained from the current credentials.
```

## Solution
Fetch the identity token in a separate step using the `gcr.io/cloud-builders/gcloud` container (where it works) and pass it via the `ID_TOKEN` environment variable. This follows the same pattern used in `staging.yaml` for Cloud Run load tests.

Also updated build triggers to exclude Gemini Enterprise files from E2E deployment tests, so changes to registration code don't trigger all template tests.