### PR TITLE
Grant SA token creator role for identity token generation

### DIFF
--- a/.cloudbuild/terraform/service_account.tf
+++ b/.cloudbuild/terraform/service_account.tf
@@ -68,3 +68,11 @@ resource "google_project_iam_member" "cicd_runner_cleanup_project_roles" {
   role    = "roles/owner"
   member  = "serviceAccount:${google_service_account.cicd_runner_sa.email}"
 }
+
+# Grant the SA permission to create identity tokens for itself
+# Required for gcloud auth print-identity-token to work in Cloud Build
+resource "google_service_account_iam_member" "cicd_runner_self_token_creator" {
+  service_account_id = google_service_account.cicd_runner_sa.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.cicd_runner_sa.email}"
+}


### PR DESCRIPTION
## Summary
- Add `roles/iam.serviceAccountTokenCreator` on the CI/CD SA itself

## Problem
The previous fix (#542) added the `fetch-id-token` step to get identity tokens in Cloud Build, but `gcloud auth print-identity-token` still fails because the SA needs permission to create tokens for itself.

## Solution
Grant the SA the `serviceAccountTokenCreator` role on itself, allowing it to generate identity tokens via `gcloud auth print-identity-token`.