### PR TITLE
Fix ADK Live event types and session handling

### DIFF
--- a/agent_starter_pack/deployment_targets/cloud_run/{{cookiecutter.agent_directory}}/fast_api_app.py
+++ b/agent_starter_pack/deployment_targets/cloud_run/{{cookiecutter.agent_directory}}/fast_api_app.py
@@ -157,7 +157,7 @@ class AgentSession:
             # Create session if needed
             if not self.session_id:
                 session = await session_service.create_session(
-                    app_name="live-app",
+                    app_name=adk_app.name,
                     user_id=self.user_id,
                 )
                 self.session_id = session.id

--- a/agent_starter_pack/frontends/adk_live_react/frontend/src/multimodal-live-types.ts
+++ b/agent_starter_pack/frontends/adk_live_react/frontend/src/multimodal-live-types.ts
@@ -244,8 +244,7 @@ export const isToolCallCancellation = (
 
 // ADK Event types
 export interface AdkEvent {
-  user_id: string;
-  session_id: string;
+  invocation_id: string;
   author: string;
   actions: {
     state_delta: any;
@@ -262,14 +261,18 @@ export interface AdkEvent {
   interrupted?: boolean;
   turn_complete?: boolean;
   partial?: boolean;
+  usage_metadata?: {
+    prompt_token_count: number;
+    total_token_count: number;
+    prompt_tokens_details?: any[];
+  };
 }
 
 // ADK Event type guards
 export const isAdkEvent = (a: unknown): a is AdkEvent =>
   typeof a === "object" &&
   a !== null &&
-  typeof (a as any).user_id === "string" &&
-  typeof (a as any).session_id === "string" &&
+  typeof (a as any).invocation_id === "string" &&
   typeof (a as any).author === "string" &&
   typeof (a as any).actions === "object";
 

--- a/agent_starter_pack/frontends/adk_live_react/frontend/src/utils/multimodal-live-client.ts
+++ b/agent_starter_pack/frontends/adk_live_react/frontend/src/utils/multimodal-live-client.ts
@@ -381,6 +381,11 @@ export class MultimodalLiveClient extends EventEmitter<MultimodalLiveClientEvent
         this.log("server.interrupted", "ADK interrupted");
       }
     } else {
+      // Ignore webpack dev server HMR messages
+      const hmrTypes = ["liveReload", "reconnect", "overlay", "hash", "ok", "warnings", "errors", "invalid", "still-ok", "hot"];
+      if (typeof (response as any).type === "string" && hmrTypes.includes((response as any).type)) {
+        return;
+      }
       console.log("received unmatched message", response);
       this.log("received unmatched message", response);
     }


### PR DESCRIPTION
## Summary
- Use dynamic app name from `adk_app.name` instead of hardcoded value
- Update `AdkEvent` interface to match current schema (invocation_id)
- Add usage_metadata field for token tracking
- Filter webpack HMR messages from console output

## Problem
The ADK Live implementation had mismatched event types and hardcoded values:
- Session creation used hardcoded "live-app" instead of actual app name
- Event types referenced obsolete user_id/session_id fields instead of invocation_id
- Webpack dev server messages cluttered logs as "unmatched messages"

## Solution
Updated type definitions to align with current ADK event schema and made session handling dynamic to support proper app naming.