### PR TITLE
Add error response validation to adk_live integration tests

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/tests/integration/test_agent_engine_app.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/tests/integration/test_agent_engine_app.py
@@ -187,6 +187,12 @@ async def test_websocket_audio_input(server_fixture: subprocess.Popen[str]) -> N
                 # Verify we got responses
                 assert len(responses) > 0, "No responses received"
 
+                # Verify no error responses
+                for idx, response in enumerate(responses):
+                    assert "error" not in response, (
+                        f"Response {idx} contains error: {response.get('error')}"
+                    )
+
                 logger.info(f"Audio test passed. Received {len(responses)} responses")
 
             finally:

--- a/agent_starter_pack/deployment_targets/cloud_run/tests/integration/test_server_e2e.py
+++ b/agent_starter_pack/deployment_targets/cloud_run/tests/integration/test_server_e2e.py
@@ -187,6 +187,12 @@ async def test_websocket_audio_input(server_fixture: subprocess.Popen[str]) -> N
                 # Verify we got responses
                 assert len(responses) > 0, "No responses received"
 
+                # Verify no error responses
+                for idx, response in enumerate(responses):
+                    assert "error" not in response, (
+                        f"Response {idx} contains error: {response.get('error')}"
+                    )
+
                 logger.info(f"Audio test passed. Received {len(responses)} responses")
 
             finally:


### PR DESCRIPTION
## Summary
- Add error checking to adk_live integration tests for both cloud_run and agent_engine deployments
- Tests now fail when responses contain error fields instead of agent output

## Problem
Integration tests only verified that responses were received, not that they were successful. Tests would pass even if all responses were error messages like `{"error": "session not found"}`.

This allowed bugs (e.g., hardcoded session IDs) to pass undetected because the test just counted `responses > 0`.

## Solution
Added simple error validation that checks each response for an `error` field and fails with a descriptive message if found.

## Testing
- ✅ `adk_live,cloud_run` - 2 integration tests passed
- ✅ `adk_live,agent_engine` - 2 integration tests passed