### PR TITLE
feat: add ASP_SKIP_VERSION_LOCK env var for testing remote templates

### DIFF
--- a/agent_starter_pack/cli/utils/remote_template.py
+++ b/agent_starter_pack/cli/utils/remote_template.py
@@ -144,7 +144,8 @@ def check_and_execute_with_version_lock(
         True if version lock was found and executed, False otherwise
     """
     # Skip version locking if we're already in a locked execution (prevents recursion)
-    if locked:
+    # or if ASP_SKIP_VERSION_LOCK env var is set to "1" (for testing with local ASP)
+    if locked or os.environ.get("ASP_SKIP_VERSION_LOCK") == "1":
         return False
     uv_lock_path = template_dir / "uv.lock"
     version = parse_agent_starter_pack_version_from_lock(uv_lock_path)

--- a/tests/cli/utils/test_remote_template.py
+++ b/tests/cli/utils/test_remote_template.py
@@ -60,10 +60,10 @@ class TestRemoteTemplateSpec:
 class TestParseAgentSpec:
     def test_parse_adk_shortcut(self) -> None:
         """Test parsing ADK shortcut format"""
-        spec = parse_agent_spec("adk@data-science")
+        spec = parse_agent_spec("adk@academic-research")
         assert spec is not None
         assert spec.repo_url == "https://github.com/google/adk-samples"
-        assert spec.template_path == "python/agents/data-science"
+        assert spec.template_path == "python/agents/academic-research"
         assert spec.git_ref == "main"
         assert spec.is_adk_samples is True
 
@@ -390,8 +390,8 @@ class TestRemoteTemplateIntegration:
                 "builtins.open",
                 mock_open(
                     read_data="""
-name: data-science
-description: Data Science Agent
+name: academic-research
+description: Academic Research Agent
 base_template: adk_base
 settings:
   requires_data_ingestion: true
@@ -401,7 +401,7 @@ settings:
             ),
         ):
             # Parse ADK samples spec
-            spec = parse_agent_spec("adk@data-science")
+            spec = parse_agent_spec("adk@academic-research")
             assert spec is not None
             assert spec.is_adk_samples is True
 
@@ -412,7 +412,7 @@ settings:
         """Test various template validation scenarios"""
         test_cases = [
             # ADK samples
-            ("adk@data-science", True),
+            ("adk@academic-research", True),
             ("adk@custom-agent", True),
             # GitHub URLs
             ("https://github.com/org/repo", True),
@@ -488,10 +488,10 @@ class TestParseAgentSpecWithGitSuffix:
 
     def test_parse_adk_shortcut_not_affected(self) -> None:
         """Ensure the adk@ shortcut remains unaffected."""
-        spec = parse_agent_spec("adk@data-science")
+        spec = parse_agent_spec("adk@academic-research")
         assert spec is not None
         assert spec.repo_url == "https://github.com/google/adk-samples"
-        assert spec.template_path == "python/agents/data-science"
+        assert spec.template_path == "python/agents/academic-research"
         assert spec.git_ref == "main"
         assert spec.is_adk_samples is True
 


### PR DESCRIPTION
## Summary
- Add `ASP_SKIP_VERSION_LOCK` env var to bypass uv.lock version constraint
- Add integration test for remote templating with local ASP version

## Problem
When testing remote templates, ASP uses the version locked in the template's `uv.lock` file. This prevents testing remote templates with the current development version of ASP.

## Solution
Add `ASP_SKIP_VERSION_LOCK` environment variable that, when set, bypasses the version lock check and uses the local ASP version instead.

```bash
ASP_SKIP_VERSION_LOCK=1 agent-starter-pack create my-agent -a adk@sample
```