### PR TITLE
fix: remove duplicate get started message and add Gemini CLI tip

### DIFF
--- a/agent_starter_pack/base_template/README.md
+++ b/agent_starter_pack/base_template/README.md
@@ -34,6 +34,8 @@ This project is organized as follows:
 └── pyproject.toml       # Project dependencies and configuration
 ```
 
+> 💡 **Tip:** Use [Gemini CLI](https://github.com/google-gemini/gemini-cli) for AI-assisted development - project context is pre-configured in `GEMINI.md`.
+
 ## Requirements
 
 Before you begin, ensure you have:

--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -797,8 +797,6 @@ def create(
                 f"   See data_ingestion/README.md for more info\n"
                 f"[bold white]=================================[/bold white]\n"
             )
-        console.print("\n> 👍 Done. Execute the following command to get started:")
-
         console.print("\n> Success! Your agent project is ready.")
         console.print(
             f"\n📖 Project README: [cyan]cat {cd_path}/README.md[/]"


### PR DESCRIPTION
## Summary
- Remove duplicate "get started" message in CLI output
- Add tip about Gemini CLI in project README

## Problem
The CLI displayed two redundant messages after project creation:
- `> 👍 Done. Execute the following command to get started:`
- `🚀 To get started, run the following command:`

This was introduced in commit 0559e419 which added new messaging but didn't remove the original.

## Solution
Removed the redundant first message. Also added a tip in the README about using Gemini CLI since project context is pre-configured.