### PR TITLE
feat: improve CLI UX with sensible defaults and -y shortcut

### DIFF
--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -5,12 +5,13 @@ Create new GCP-based AI agent projects from built-in agents or remote templates.
 ## Usage
 
 ```bash
-uvx agent-starter-pack create PROJECT_NAME [OPTIONS]
+uvx agent-starter-pack create [PROJECT_NAME] [OPTIONS]
 ```
 
 ## Arguments
 
-- `PROJECT_NAME`: Name for your new agent project directory and base for resource naming.
+- `PROJECT_NAME` (optional): Name for your new agent project directory and base for resource naming.
+  If omitted, you'll be prompted interactively (or defaults to `my-agent` with `--auto-approve`).
   *Note: This name will be converted to lowercase and must be 26 characters or less.*
 
 ## Template Selection
@@ -130,8 +131,12 @@ uvx agent-starter-pack create my-agent -a template --in-folder
 
 ## Automation Options
 
-### `--auto-approve`
-Skip interactive confirmation prompts for GCP credentials and region.
+### `--auto-approve`, `--yes`, `-y`
+Skip interactive confirmation prompts and use sensible defaults:
+- Project name defaults to `my-agent`
+- Agent defaults to first available (typically `adk_base`)
+- Deployment target defaults to `agent_engine`
+- CI/CD runner defaults to `google_cloud_build`
 
 ### `--skip-checks`
 Skip verification checks for GCP authentication and Vertex AI connection.
@@ -141,10 +146,20 @@ Enable debug logging for troubleshooting.
 
 ## Examples
 
+### Quick Start
+
+```bash
+# Create with all defaults (project: my-agent, agent: adk_base, target: agent_engine)
+uvx agent-starter-pack create -y
+
+# Fully interactive mode
+uvx agent-starter-pack create
+```
+
 ### Basic Usage
 
 ```bash
-# Create a new project interactively
+# Create a new project with specific name
 uvx agent-starter-pack create my-agent-project
 
 # Create with specific built-in agent
@@ -186,7 +201,7 @@ uvx agent-starter-pack create my-agent -a adk@data-science --in-folder
 uvx agent-starter-pack create my-agent -a adk_base --agent-directory chatbot
 
 # Skip all prompts for automation
-uvx agent-starter-pack create my-agent -a template-url --auto-approve --skip-checks
+uvx agent-starter-pack create my-agent -a template-url -y --skip-checks
 ```
 
 ### Output Directory

--- a/docs/cli/enhance.md
+++ b/docs/cli/enhance.md
@@ -40,7 +40,7 @@ Name of the agent directory (overrides template default, usually `app`). This de
 - `--deployment-target, -d` - Deployment target (`agent_engine`, `cloud_run`)
 - `--include-data-ingestion, -i` - Include data ingestion pipeline
 - `--session-type` - Session storage type
-- `--auto-approve` - Skip confirmation prompts
+- `--auto-approve, --yes, -y` - Skip confirmation prompts and use defaults
 - And all other `create` command options
 
 ## Examples
@@ -179,15 +179,15 @@ The `enhance` command automatically creates a complete backup of your project be
 ## Best Practices
 
 1. **Review Backup:** Check that the backup was created successfully
-2. **Follow Structure:** Organize your agent code in `/app/agent.py` for best compatibility  
-3. **Test Locally:** Use `--auto-approve` in CI/CD but test interactively first
+2. **Follow Structure:** Organize your agent code in `/app/agent.py` for best compatibility
+3. **Test Locally:** Use `-y` in CI/CD but test interactively first
 4. **Review Changes:** After enhancement, review the generated files and configuration
 
 ## Troubleshooting
 
 **"Project structure warning"**
 - Organize your agent code in an `/app` folder (or specify custom directory with `--agent-directory`)
-- Use `--auto-approve` to skip the confirmation prompt
+- Use `-y` to skip the confirmation prompt
 
 **"Enhancement cancelled"**
 - Create an `/app` folder with your `agent.py` file


### PR DESCRIPTION
## Summary
- Add `--yes`/`-y` as aliases for `--auto-approve` flag
- Make project name optional (prompts interactively or defaults to `my-agent`)
- Default to first available agent in auto-approve mode

## Usage

Before:
```bash
agent-starter-pack create my-project --agent adk_base --auto-approve
```

After:
```bash
agent-starter-pack create -y
```