### PR TITLE
fix: use gs:// URI format for artifact_service_uri in Cloud Run

### DIFF
--- a/agent_starter_pack/deployment_targets/cloud_run/{{cookiecutter.agent_directory}}/fast_api_app.py
+++ b/agent_starter_pack/deployment_targets/cloud_run/{{cookiecutter.agent_directory}}/fast_api_app.py
@@ -451,10 +451,12 @@ else:
 session_service_uri = None
 {%- endif %}
 
+artifact_service_uri = f"gs://{logs_bucket_name}" if logs_bucket_name else None
+
 app: FastAPI = get_fast_api_app(
     agents_dir=AGENT_DIR,
     web=True,
-    artifact_service_uri=logs_bucket_name,
+    artifact_service_uri=artifact_service_uri,
     allow_origins=allow_origins,
     session_service_uri=session_service_uri,
     otel_to_cloud=True,


### PR DESCRIPTION
## Summary
- Fix `artifact_service_uri` parameter to use proper GCS URI format (`gs://bucket-name`)
- Extract URI construction to a separate variable for readability

## Problem
The ADK's `get_fast_api_app` function expects `artifact_service_uri` in URI format (e.g., `gs://my-bucket`), but the code was passing just the bucket name without the `gs://` prefix.

## Solution
Convert the bucket name to a proper GCS URI before passing it to `get_fast_api_app`.