### PR TITLE
fix: force GOOGLE_CLOUD_LOCATION env variable assignment

### DIFF
--- a/agent_starter_pack/agents/adk_a2a_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_a2a_base/app/agent.py
@@ -21,9 +21,9 @@ from google.adk.agents import Agent
 from google.adk.apps.app import App
 
 _, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
-os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 
 
 def get_weather(query: str) -> str:

--- a/agent_starter_pack/agents/adk_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_base/app/agent.py
@@ -21,9 +21,9 @@ from google.adk.agents import Agent
 from google.adk.apps.app import App
 
 _, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
-os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 
 
 def get_weather(query: str) -> str:

--- a/agent_starter_pack/agents/adk_live/app/agent.py
+++ b/agent_starter_pack/agents/adk_live/app/agent.py
@@ -20,9 +20,9 @@ from google.adk.agents import Agent
 from google.adk.apps.app import App
 
 _, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "us-central1")
-os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
+os.environ["GOOGLE_CLOUD_LOCATION"] = "us-central1"
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 
 vertexai.init(project=project_id, location="us-central1")
 

--- a/agent_starter_pack/agents/agentic_rag/app/agent.py
+++ b/agent_starter_pack/agents/agentic_rag/app/agent.py
@@ -30,9 +30,9 @@ LOCATION = "us-central1"
 LLM = "gemini-3-pro-preview"
 
 credentials, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", LLM_LOCATION)
-os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
+os.environ["GOOGLE_CLOUD_LOCATION"] = LLM_LOCATION
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 
 vertexai.init(project=project_id, location=LOCATION)
 embedding = VertexAIEmbeddings(


### PR DESCRIPTION
## Summary
- Replace `os.environ.setdefault` with direct assignment for `GOOGLE_CLOUD_LOCATION`
- Applied to all 4 agent templates (adk_base, adk_live, adk_a2a_base, agentic_rag)

## Problem
Using `setdefault` means the environment variable would not be updated if a different value was already set, which could cause unexpected behavior.

## Solution
Use direct assignment `os.environ["GOOGLE_CLOUD_LOCATION"] = ...` to ensure the agent always uses the expected location value.