### PR TITLE
feat: add -s shortcut for --skip-checks flag

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -66,6 +66,7 @@ def shared_template_options(f: Callable) -> Callable:
         default=False,
     )(f)
     f = click.option(
+        "-s",
         "--skip-checks",
         is_flag=True,
         help="Skip verification checks for GCP and Vertex AI",


### PR DESCRIPTION
## Summary
- Add `-s` as a short alias for `--skip-checks` in the create command

## Usage
```bash
agent-starter-pack create myproject -s
```