### PR TITLE
feat: add --google-api-key option for AI Studio support

### DIFF
--- a/agent_starter_pack/agents/adk_a2a_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_a2a_base/app/agent.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +14,20 @@
 # limitations under the License.
 
 import datetime
-import os
 from zoneinfo import ZoneInfo
 
-import google.auth
 from google.adk.agents import Agent
 from google.adk.apps.app import App
+{%- if not cookiecutter.use_google_api_key %}
+
+import os
+import google.auth
 
 _, project_id = google.auth.default()
 os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
 os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+{%- endif %}
 
 
 def get_weather(query: str) -> str:

--- a/agent_starter_pack/agents/adk_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_base/app/agent.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +14,20 @@
 # limitations under the License.
 
 import datetime
-import os
 from zoneinfo import ZoneInfo
 
-import google.auth
 from google.adk.agents import Agent
 from google.adk.apps.app import App
+{%- if not cookiecutter.use_google_api_key %}
+
+import os
+import google.auth
 
 _, project_id = google.auth.default()
 os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
 os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+{%- endif %}
 
 
 def get_weather(query: str) -> str:

--- a/agent_starter_pack/agents/adk_live/app/agent.py
+++ b/agent_starter_pack/agents/adk_live/app/agent.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-import google.auth
-import vertexai
 from google.adk.agents import Agent
 from google.adk.apps.app import App
+{%- if not cookiecutter.use_google_api_key %}
+
+import os
+import google.auth
+import vertexai
 
 _, project_id = google.auth.default()
 os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
@@ -25,6 +27,7 @@ os.environ["GOOGLE_CLOUD_LOCATION"] = "us-central1"
 os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 
 vertexai.init(project=project_id, location="us-central1")
+{%- endif %}
 
 
 def get_weather(query: str) -> str:

--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -59,6 +59,12 @@ def shared_template_options(f: Callable) -> Callable:
     """Decorator to add shared options for template-based commands."""
     # Apply options in reverse order since decorators are applied bottom-up
     f = click.option(
+        "--google-api-key",
+        type=str,
+        help="Use Google AI Studio API key instead of Vertex AI. Generates a .env file with the provided API key.",
+        default=None,
+    )(f)
+    f = click.option(
         "-ag",
         "--agent-garden",
         is_flag=True,
@@ -273,6 +279,7 @@ def create(
     skip_welcome: bool = False,
     locked: bool = False,
     cli_overrides: dict | None = None,
+    google_api_key: str | None = None,
 ) -> None:
     """Create GCP-based AI agent projects from templates."""
     try:
@@ -714,11 +721,19 @@ def create(
         if debug:
             logging.debug(f"Selected region: {region}")
 
+        # Validate google_api_key is not used with langgraph agents
+        if google_api_key and "langgraph" in final_agent.lower():
+            raise click.ClickException(
+                "--google-api-key is not supported for LangGraph agents. "
+                "You can modify the generated template to use ChatGoogleGenerativeAI class instead. "
+                "See https://docs.langchain.com/oss/python/integrations/chat/google_generative_ai"
+            )
+
         # GCP Setup
         logging.debug("Setting up GCP...")
 
         creds_info = {}
-        if not skip_checks:
+        if not skip_checks and not google_api_key:
             # Set up GCP environment
             try:
                 creds_info = setup_gcp_environment(
@@ -777,6 +792,7 @@ def create(
                 cli_overrides=final_cli_overrides,
                 agent_garden=agent_garden,
                 remote_spec=remote_spec,
+                google_api_key=google_api_key,
             )
 
             # Replace region in all files if a different region was specified

--- a/agent_starter_pack/cli/commands/enhance.py
+++ b/agent_starter_pack/cli/commands/enhance.py
@@ -266,6 +266,7 @@ def enhance(
     base_template: str | None,
     adk: bool,
     agent_directory: str | None,
+    google_api_key: str | None = None,
 ) -> None:
     """Enhance your existing project with AI agent capabilities.
 
@@ -642,4 +643,5 @@ def enhance(
         base_template=base_template,
         skip_welcome=True,  # Skip welcome message since enhance shows its own
         cli_overrides=final_cli_overrides if final_cli_overrides else None,
+        google_api_key=google_api_key,
     )

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -750,6 +750,7 @@ def process_template(
     cli_overrides: dict[str, Any] | None = None,
     agent_garden: bool = False,
     remote_spec: Any | None = None,
+    google_api_key: str | None = None,
 ) -> None:
     """Process the template directory and create a new project.
 
@@ -768,6 +769,7 @@ def process_template(
         in_folder: Whether to template directly into the output directory instead of creating a subdirectory
         cli_overrides: Optional CLI override values that should take precedence over template config
         agent_garden: Whether this deployment is from Agent Garden
+        google_api_key: Optional Google AI Studio API key to generate .env file
     """
     logging.debug(f"Processing template from {template_dir}")
     logging.debug(f"Project name: {project_name}")
@@ -1040,6 +1042,7 @@ def process_template(
                 "agent_garden": agent_garden,
                 "agent_sample_id": agent_sample_id or "",
                 "agent_sample_publisher": agent_sample_publisher or "",
+                "use_google_api_key": bool(google_api_key),
                 "adk_cheatsheet": adk_cheatsheet_content,
                 "llm_txt": llm_txt_content,
                 "_copy_without_render": [
@@ -1421,6 +1424,19 @@ def process_template(
                     )
                     lock_file.truncate()
                 logging.debug(f"Updated project name in lock file at {lock_file_path}")
+
+            # Generate .env file for Google API Key if provided
+            if google_api_key:
+                env_file_path = final_destination / agent_directory / ".env"
+                env_content = f"""# AI Studio Configuration
+GOOGLE_API_KEY={google_api_key}
+"""
+                env_file_path.write_text(env_content)
+                logging.debug(f"Generated .env file at {env_file_path}")
+                console.print(
+                    f"📝 Generated .env file at [cyan]{agent_directory}/.env[/cyan] "
+                    "for Google AI Studio"
+                )
 
         except Exception as e:
             logging.error(f"Failed to process template: {e!s}")


### PR DESCRIPTION
## Summary
- Add `--google-api-key` CLI option to use Google AI Studio instead of Vertex AI
- Generate `.env` file with API key when flag is passed
- Skip GCP credential checks when using API key
- Conditionally exclude Vertex AI initialization code from agent templates

e.g
uvx agent-starter-pack create my-agent -y --google-api-key your-api-key

