### PR TITLE
feat: add -k and --api-key shorthand for --google-api-key

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -59,10 +59,13 @@ def shared_template_options(f: Callable) -> Callable:
     """Decorator to add shared options for template-based commands."""
     # Apply options in reverse order since decorators are applied bottom-up
     f = click.option(
+        "-k",
         "--google-api-key",
-        type=str,
-        help="Use Google AI Studio API key instead of Vertex AI. Generates a .env file with the provided API key.",
+        "--api-key",
+        is_flag=False,
+        flag_value="YOUR_API_KEY",
         default=None,
+        help="Use Google AI Studio API key instead of Vertex AI. If provided without a value, generates a .env file with a placeholder.",
     )(f)
     f = click.option(
         "-ag",

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -138,6 +138,9 @@ Skip interactive confirmation prompts and use sensible defaults:
 - Deployment target defaults to `agent_engine`
 - CI/CD runner defaults to `google_cloud_build`
 
+### `--google-api-key`, `--api-key`, `-k` [KEY]
+Use Google AI Studio API key instead of Vertex AI. If provided without a value, generates a `.env` file with a `YOUR_API_KEY` placeholder.
+
 ### `--skip-checks`
 Skip verification checks for GCP authentication and Vertex AI connection.
 

--- a/docs/cli/enhance.md
+++ b/docs/cli/enhance.md
@@ -40,6 +40,7 @@ Name of the agent directory (overrides template default, usually `app`). This de
 - `--deployment-target, -d` - Deployment target (`agent_engine`, `cloud_run`)
 - `--include-data-ingestion, -i` - Include data ingestion pipeline
 - `--session-type` - Session storage type
+- `--google-api-key, --api-key, -k` - Use Google AI Studio API key (or placeholder if no value provided)
 - `--auto-approve, --yes, -y` - Skip confirmation prompts and use defaults
 - And all other `create` command options
 


### PR DESCRIPTION
## Summary
- Add `-k` short flag and `--api-key` alias for `--google-api-key`
- Update docs for both `create` and `enhance` commands