### PR TITLE
fix: display actual account in interactive credentials flow

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -1150,7 +1150,7 @@ def _handle_interactive_credentials(context: str | None = None) -> dict:
     # First, get credentials to show to user
     console.print("> Verifying GCP credentials...")
     try:
-        creds_info = verify_credentials_and_vertex(context=context, auto_approve=True)
+        creds_info = verify_credentials_and_vertex(context=context, auto_approve=False)
     except Exception:
         # If verification fails, we still want to show what we can and let user fix it
         import google.auth


### PR DESCRIPTION
## Summary
- Fix account display showing 'N/A' instead of actual email in interactive mode

## Problem
When running `agent-starter-pack create` without `-y`, users saw:
```
> You are logged in with account: 'N/A'
```

The `_handle_interactive_credentials` function was calling `verify_credentials_and_vertex` with `auto_approve=True`, which skips fetching the account email as a performance optimization intended for non-interactive flows.

## Solution
Changed to `auto_approve=False` so the account email is properly fetched and displayed.