### PR TITLE
fix: simplify enhance command hint by removing version suffix

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -48,7 +48,6 @@ from ..utils.template import (
     prompt_deployment_target,
     prompt_session_type_selection,
 )
-from ..utils.version import get_current_version
 
 console = Console()
 
@@ -950,9 +949,8 @@ def create(
         )
         # Show enhance hint for prototype mode
         if final_cicd_runner == "skip":
-            version = get_current_version()
             console.print(
-                f"\n💡 Once ready for production, run: [cyan]uvx agent-starter-pack@{version} enhance[/]"
+                "\n💡 Once ready for production, run: [cyan]uvx agent-starter-pack enhance[/]"
             )
         # Determine the correct path to display based on whether output_dir was specified
         console.print("\n🚀 To get started, run the following command:")


### PR DESCRIPTION
## Summary
- Remove version suffix from enhance command hint in prototype mode output
- Remove unused `get_current_version` import

## Problem
The enhance hint displayed `uvx agent-starter-pack@0.26.2 enhance` with a hardcoded version, but this is unnecessary since the enhance command already reads the locked version from the project's `pyproject.toml` metadata.

## Solution
Simplified the hint to just `uvx agent-starter-pack enhance`, matching the format already used in the base template README.