### PR TITLE
docs: simplify create command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Focus on your agent logic—the starter pack provides everything else: infrastru
 **From zero to production-ready agent in 60 seconds using [`uv`](https://docs.astral.sh/uv/getting-started/installation/):**
 
 ```bash
-uvx agent-starter-pack create my-awesome-agent
+uvx agent-starter-pack create
 ```
 
 <details>
@@ -45,7 +45,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install --upgrade agent-starter-pack
 
 # Create a new agent project
-agent-starter-pack create my-awesome-agent
+agent-starter-pack create
 ```
 </details>
 

--- a/docs/guide/development-guide.md
+++ b/docs/guide/development-guide.md
@@ -19,12 +19,12 @@ source .venv/bin/activate
 pip install agent-starter-pack
 
 # 3. Run the create command
-agent-starter-pack create my-awesome-agent
+agent-starter-pack create
 ```
 
 ```bash [⚡ uvx]
 # This single command downloads and runs the latest version
-uvx agent-starter-pack create my-awesome-agent
+uvx agent-starter-pack create
 ```
 :::
 
@@ -33,7 +33,7 @@ uvx agent-starter-pack create my-awesome-agent
 Navigate into your new project to begin development.
 
 ```bash
-cd my-awesome-agent
+cd <your-project>
 ```
 
 Inside, you'll find a complete project structure:
@@ -68,7 +68,7 @@ Add new dependencies with `uv add <package>` and remove them with `uv remove <pa
 
 Once you're satisfied with local testing, you are ready to deploy your agent to Google Cloud. The process involves two main stages: first, deploying to a hands-on development environment for quick iteration, and second, setting up a formal CI/CD pipeline for staging and production.
 
-*All `make` commands should be run from the root of your agent project (`my-awesome-agent`).*
+*All `make` commands should be run from the root of your agent project.*
 
 ### Stage 1: Deploy to a Cloud Development Environment
 
@@ -107,7 +107,7 @@ Once you've refined your agent in the development environment, the next stage is
 
 #### Option 1: Automated CI/CD Setup
 
-From the root of your agent project (`my-awesome-agent`), run:
+From the root of your agent project, run:
 ```bash
 agent-starter-pack setup-cicd
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,12 +23,12 @@ source .venv/bin/activate
 pip install agent-starter-pack
 
 # 3. Run the create command
-agent-starter-pack create my-awesome-agent
+agent-starter-pack create
 ```
 
 ```bash [⚡ uvx]
 # This single command downloads and runs the latest version
-uvx agent-starter-pack create my-awesome-agent
+uvx agent-starter-pack create
 ```
 
 :::
@@ -50,10 +50,10 @@ agent-starter-pack create my-adk-agent -a adk_base -d agent_engine
 Now, navigate into your new project and run its setup commands.
 
 ```bash
-cd my-awesome-agent && make install && make playground
+cd <your-project> && make install && make playground
 ```
 
-Inside your new project directory (`my-awesome-agent`), you'll find:
+Inside your new project directory, you'll find:
 
 *   `app/`: Backend agent code (or custom directory name if configured).
 *   `deployment/`: Terraform infrastructure code.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -8,7 +8,7 @@ There are several ways to install the Agent Starter Pack. Choose the method that
 
 If you have [uv](https://astral.sh/uv) installed, you can create projects without a permanent installation:
 ```bash
-uvx agent-starter-pack create my-awesome-agent
+uvx agent-starter-pack create
 ```
 
 ## Virtual Environment Installation
@@ -46,7 +46,7 @@ uv tool install agent-starter-pack
 
 If you installed via `pipx`, `uv tool install`, or in a virtual environment:
 ```bash
-agent-starter-pack create my-awesome-agent
+agent-starter-pack create
 ```
 
 ## Managing Installation


### PR DESCRIPTION
## Summary
- Remove hardcoded `my-awesome-agent` from create command examples
- CLI prompts for project name interactively, making the argument unnecessary