### PR TITLE
fix: use direct env var assignment in langgraph_base

### DIFF
--- a/agent_starter_pack/agents/langgraph_base/app/agent.py
+++ b/agent_starter_pack/agents/langgraph_base/app/agent.py
@@ -26,9 +26,9 @@ load_dotenv()
 import google.auth
 
 _, project_id = google.auth.default()
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", project_id)
-os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "global")
-os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 {%- endif %}
 
 LLM = "gemini-3-pro-preview"


### PR DESCRIPTION
## Summary
- Use direct `os.environ[]` assignment instead of `setdefault` for consistency with other agents