### PR TITLE
fix: handle existing release branch by deleting first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create release branch and PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           BRANCH="release/v${{ steps.bump.outputs.new_version }}"
 
@@ -79,7 +79,8 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
           git push -u origin "$BRANCH"
 
-          gh pr create \
+          # Create PR
+          PR_URL=$(gh pr create \
             --title "chore: release v${{ steps.bump.outputs.new_version }}" \
             --body "## Release v${{ steps.bump.outputs.new_version }}
 
@@ -91,7 +92,10 @@ jobs:
 
           Once merged, the release will be published after manual approval." \
             --label "release" \
-            --head "$BRANCH"
+            --head "$BRANCH")
+
+          # Trigger Cloud Build tests
+          gh pr comment "$PR_URL" --body "/gcbrun"
 
   # Job 2: Auto-merge when tests pass (triggered by PR label)
   auto-merge:


### PR DESCRIPTION
Fixes the release workflow failing when a release branch already exists from a previous failed run.