### PR TITLE
fix: use triggering user as commit author for CLA compliance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update lock file
-        run: uv lock
+        run: uv lock --package agent-starter-pack
 
       - name: Create release branch and PR
         env:


### PR DESCRIPTION
Uses `github.actor` instead of `github-actions[bot]` as the commit author so CLA checks pass.