### PR TITLE
fix: install uv before running uv lock in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
       - name: Configure git
         run: |
           git config user.name "${{ github.actor }}"


### PR DESCRIPTION
Fixes release workflow failing due to missing uv command.