### PR TITLE
fix: enable auto-merge with PAT in PR creation step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,21 +102,10 @@ jobs:
             --label "release" \
             --head "$BRANCH")
 
-  # Job 2: Auto-merge when tests pass (triggered by PR label)
-  auto-merge:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == false && contains(github.event.pull_request.labels.*.name, 'release')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr merge ${{ github.event.pull_request.number }} \
-            --auto \
-            --squash \
-            --repo ${{ github.repository }}
+          # Enable auto-merge
+          gh pr merge "$PR_URL" --auto --squash
 
-  # Job 3: Publish release (triggered when release PR is merged)
+  # Job 2: Publish release (triggered when release PR is merged)
   publish:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moves auto-merge into the PR creation step so it uses RELEASE_PAT instead of GITHUB_TOKEN.