### PR TITLE
fix: exclude A2A and ADK Live from agent_framework parameter

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -407,7 +407,7 @@ def deploy_agent_engine_app(
         max_instances=max_instances,
         resource_limits={"cpu": cpu, "memory": memory},
         container_concurrency=container_concurrency,
-{%- if cookiecutter.is_adk %}
+{%- if cookiecutter.is_adk and not cookiecutter.is_a2a and not cookiecutter.is_adk_live %}
         agent_framework="google-adk",
 {%- endif %}
     )


### PR DESCRIPTION
## Summary
- Restrict `agent_framework="google-adk"` to standard ADK agents only
- Exclude A2A and ADK Live agents which use different deployment mechanisms

## Problem
The `agent_framework` parameter was being set for all ADK agents, but A2A and ADK Live agents have their own deployment paths and should not include this parameter.

## Solution
Updated the Jinja condition from `is_adk` to `is_adk and not is_a2a and not is_adk_live`.