### PR TITLE
docs: add CodeWiki link for codebase exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ This starter pack covers all aspects of Agent development, from prototyping and 
 
 Visit our [documentation site](https://googlecloudplatform.github.io/agent-starter-pack/) for comprehensive guides and references!
 
+🔍 **New to the codebase?** Explore the [CodeWiki](https://codewiki.google/github.com/googlecloudplatform/agent-starter-pack) for AI-powered code understanding and navigation.
+
 - [Getting Started Guide](https://googlecloudplatform.github.io/agent-starter-pack/guide/getting-started) - First steps with agent-starter-pack
 - [Installation Guide](https://googlecloudplatform.github.io/agent-starter-pack/guide/installation) - Setting up your environment
 - [Deployment Guide](https://googlecloudplatform.github.io/agent-starter-pack/guide/deployment) - Taking your agent to production

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -71,3 +71,4 @@ You're ready to go! See the [Development Guide](/guide/development-guide) for de
 - **Add Data (RAG):** Configure [Data Ingestion](/guide/data-ingestion) for knowledge-based agents.
 - **Monitor Performance:** Explore [Observability](/guide/observability) features for production monitoring.
 - **Deploy to Production:** Follow the [Deployment Guide](/guide/deployment) to deploy your agent to Google Cloud.
+- **Explore the Code:** Use [CodeWiki](https://codewiki.google/github.com/googlecloudplatform/agent-starter-pack) for AI-powered code navigation and understanding.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,4 @@ Help us spread the word by giving us a star on GitHub!
 - **Explore Templates:** [Agent Templates Overview](/agents/overview)
 - **Community:** [Community Showcase](/guide/community-showcase)
 - **Command Line:** [CLI Reference](/cli/)
+- **Explore the Code:** [CodeWiki](https://codewiki.google/github.com/googlecloudplatform/agent-starter-pack) - AI-powered code understanding


### PR DESCRIPTION
## Summary
- Add CodeWiki hyperlink to README, docs homepage, and getting started guide
- Helps new contributors explore the codebase with AI-powered navigation

## Changes
- `README.md`: Added link in Documentation section
- `docs/index.md`: Added to Quick Links
- `docs/guide/getting-started.md`: Added to Next Steps