### PR TITLE
feat: display agent card URL for A2A deployments

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -138,6 +138,8 @@ def print_deployment_success(
     print(
         "\n✅ Deployment successful! Test your agent: notebooks/adk_a2a_app_testing.ipynb"
     )
+    agent_card_url = f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project}/locations/{location}/reasoningEngines/{agent_engine_id}/a2a/v1/card"
+    print(f"🪪 Agent Card URL: {agent_card_url}")
 {%- else %}
     print("\n✅ Deployment successful!")
 {%- endif %}


### PR DESCRIPTION
## Summary
- Print the A2A agent card URL after successful deployment to Agent Engine
- URL format: `https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project}/locations/{location}/reasoningEngines/{id}/a2a/v1/card`

## Problem
When deploying A2A agents to Agent Engine, users need to manually construct the agent card URL to share or test the agent's A2A endpoint.

## Solution
Added the agent card URL output to the deployment success message for A2A agents, making it immediately accessible after deployment.