### PR TITLE
fix: wait for all checks before merging release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,13 @@ jobs:
           # Approve with second account's PAT (different user than PR author)
           gh pr review "${{ steps.create_pr.outputs.pr_url }}" --approve
 
+      - name: Wait for all checks to pass
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          echo "Waiting for all status checks to complete..."
+          gh pr checks "${{ steps.create_pr.outputs.pr_url }}" --watch --fail-fast
+
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary
- Add step to wait for all status checks before enabling auto-merge on release PRs

## Problem
Release PRs were being merged immediately after auto-merge was enabled, without waiting for CI checks to complete.

## Solution
Added `gh pr checks --watch --fail-fast` step before enabling auto-merge. This ensures all checks pass before proceeding with the merge.