### PR TITLE
fix: default CI/CD runner to simple mode (skip)

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -787,9 +787,9 @@ def create(
         elif cicd_runner:
             final_cicd_runner = cicd_runner
         elif auto_approve:
-            final_cicd_runner = "google_cloud_build"
+            final_cicd_runner = "skip"
             console.print(
-                "Info: --cicd-runner not specified. Defaulting to 'google_cloud_build' in auto-approve mode.",
+                "Info: --cicd-runner not specified. Defaulting to 'skip' (simple mode) in auto-approve mode.",
                 style="yellow",
             )
         else:

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -502,6 +502,10 @@ def prompt_cicd_runner_selection() -> str:
     console = Console()
 
     cicd_runners = {
+        "skip": {
+            "display_name": "Simple",
+            "description": "Minimal - no CI/CD or Terraform, add later with 'enhance'",
+        },
         "google_cloud_build": {
             "display_name": "Google Cloud Build",
             "description": "Fully managed CI/CD, deeply integrated with GCP for fast, consistent builds and deployments.",
@@ -509,10 +513,6 @@ def prompt_cicd_runner_selection() -> str:
         "github_actions": {
             "display_name": "GitHub Actions",
             "description": "GitHub Actions: CI/CD with secure workload identity federation directly in GitHub.",
-        },
-        "skip": {
-            "display_name": "Skip",
-            "description": "Minimal - no CI/CD or Terraform, add later with 'enhance'",
         },
     }
 

--- a/tests/cli/commands/test_enhance.py
+++ b/tests/cli/commands/test_enhance.py
@@ -650,7 +650,8 @@ app = App(root_agent=root_agent, name="app")
 """
             agent_file.write_text(agent_content)
 
-            # Run enhance with cloud_run deployment target
+            # Run enhance with cloud_run deployment target and explicit cicd-runner
+            # (auto-approve defaults to 'skip' which doesn't generate Terraform)
             result = runner.invoke(
                 enhance,
                 [
@@ -659,6 +660,8 @@ app = App(root_agent=root_agent, name="app")
                     "adk_base",
                     "--deployment-target",
                     "cloud_run",
+                    "--cicd-runner",
+                    "google_cloud_build",
                     "--auto-approve",
                     "--skip-checks",
                 ],


### PR DESCRIPTION
## Summary
- Reorder CI/CD runner options to make 'Simple' (skip) the default
- Update auto-approve mode to default to 'skip' instead of 'google_cloud_build'
- Fix test to explicitly specify cicd-runner when Terraform files are expected

## Problem
The create command defaulted to 'google_cloud_build' as the CI/CD runner in both interactive and auto-approve modes. Users expected 'simple' (no CI/CD or Terraform) to be the default, allowing them to enhance later when ready for production.

## Solution
- Moved 'skip' to first position in the cicd_runners dict for interactive prompt
- Changed auto-approve default from 'google_cloud_build' to 'skip'
- Renamed the option label from 'Skip' to 'Simple' for clearer UX