### PR TITLE
fix: explicitly set CICD runner in E2E tests

### DIFF
--- a/tests/cicd/test_e2e_deployment.py
+++ b/tests/cicd/test_e2e_deployment.py
@@ -1190,6 +1190,11 @@ class TestE2EDeployment:
                 extra_params = config.extra_params.split(",")
                 cmd.extend(extra_params)
 
+            # Add default CICD runner (google_cloud_build) if not explicitly set in extra_params
+            # This is needed because the CLI default changed to "skip"
+            if "--cicd-runner" not in config.extra_params:
+                cmd.extend(["--cicd-runner", "google_cloud_build"])
+
             # Add default session type for cloud_run deployment if not explicitly set
             if config.deployment_target == "cloud_run":
                 # Check if session-type is already in extra_params


### PR DESCRIPTION
## Summary
- Add explicit `--cicd-runner google_cloud_build` flag to E2E test create command
- Ensures E2E tests continue to test CI/CD pipelines after CLI default changed to "skip"

## Problem
PR #647 changed the default CI/CD runner to "skip" mode for local development simplicity. However, E2E deployment tests rely on having CI/CD infrastructure to test the full deployment pipeline.

## Solution
Explicitly pass `--cicd-runner google_cloud_build` when the test config doesn't already specify a CI/CD runner, ensuring tests create projects with proper CI/CD setup.