### PR TITLE
Refactor environment variable loading to runtime

### DIFF
--- a/agent_starter_pack/base_template/README.md
+++ b/agent_starter_pack/base_template/README.md
@@ -28,7 +28,9 @@ This project is organized as follows:
 {%- endif %}
 {%- if cookiecutter.cicd_runner != 'skip' %}
 ├── deployment/          # Infrastructure and deployment scripts
+{%- if cookiecutter.agent_name != 'adk_live' %}
 ├── notebooks/           # Jupyter notebooks for prototyping and evaluation
+{%- endif %}
 {%- endif %}
 ├── tests/               # Unit, integration, and load tests
 ├── Makefile             # Makefile for common commands

--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/agent_engine_app.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/agent_engine_app.py
@@ -27,6 +27,9 @@ import nest_asyncio
 import vertexai
 {%- if cookiecutter.is_a2a %}
 from a2a.types import AgentCapabilities, AgentCard, TransportProtocol
+{%- endif %}
+from dotenv import load_dotenv
+{%- if cookiecutter.is_a2a %}
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.a2a.utils.agent_card_builder import AgentCardBuilder
 from google.adk.apps.app import App
@@ -53,6 +56,9 @@ from {{cookiecutter.agent_directory}}.agent import app as adk_app
 {%- endif %}
 from {{cookiecutter.agent_directory}}.app_utils.telemetry import setup_telemetry
 from {{cookiecutter.agent_directory}}.app_utils.typing import Feedback
+
+# Load environment variables from .env file at runtime
+load_dotenv()
 {%- if cookiecutter.is_a2a %}
 
 
@@ -182,6 +188,7 @@ from typing import Any
 import nest_asyncio
 import vertexai
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill, TransportProtocol
+from dotenv import load_dotenv
 from google.cloud import logging as google_cloud_logging
 from vertexai.preview.reasoning_engines import A2aAgent
 
@@ -191,6 +198,9 @@ from {{cookiecutter.agent_directory}}.app_utils.executor.a2a_agent_executor impo
 )
 from {{cookiecutter.agent_directory}}.app_utils.telemetry import setup_telemetry
 from {{cookiecutter.agent_directory}}.app_utils.typing import Feedback
+
+# Load environment variables from .env file at runtime
+load_dotenv()
 
 # Capture the location before vertexai.init() might change it
 gemini_location = os.environ.get("GOOGLE_CLOUD_LOCATION")

--- a/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -18,14 +18,12 @@ import importlib
 import inspect
 import json
 import logging
-import os
 import warnings
 from typing import Any
 
 import click
 import google.auth
 import vertexai
-from dotenv import dotenv_values
 from vertexai._genai import _agent_engines_utils
 from vertexai._genai.types import AgentEngine, AgentEngineConfig{%- if cookiecutter.is_adk_live %}, AgentServerMode{%- endif %}
 {%- if cookiecutter.is_adk_live %}
@@ -68,35 +66,6 @@ def parse_key_value_pairs(kv_string: str | None) -> dict[str, str]:
             else:
                 logging.warning(f"Skipping malformed key-value pair: {pair}")
     return result
-
-
-def load_env_file(env_file_path: str | None, app_directory: str) -> dict[str, str]:
-    """Load environment variables from a .env file and return as dictionary."""
-    # Determine which .env file to use
-    if env_file_path:
-        target_file = env_file_path
-    else:
-        target_file = os.path.join(app_directory, ".env")
-
-    if not os.path.exists(target_file):
-        if env_file_path:  # Only warn if a specific file was explicitly provided
-            logging.warning(f"Specified env file not found: {target_file}")
-        return {}
-
-    logging.info(f"Loading environment variables from {target_file}")
-    env_vars = dotenv_values(target_file)
-
-    # Filter out GOOGLE_CLOUD_* variables - these are managed by the deployment
-    filtered_vars = {}
-    for key, value in env_vars.items():
-        if value is None:
-            continue
-        if key.startswith("GOOGLE_CLOUD_"):
-            logging.info(f"Ignoring {key} from .env (managed by deployment)")
-            continue
-        filtered_vars[key] = value
-
-    return filtered_vars
 
 
 def write_deployment_metadata(
@@ -203,14 +172,9 @@ def print_deployment_success(
     help="Path to requirements.txt file",
 )
 @click.option(
-    "--env-file",
-    default=None,
-    help="Path to .env file for environment variables (defaults to {{cookiecutter.agent_directory}}/.env)",
-)
-@click.option(
     "--set-env-vars",
     default=None,
-    help="Comma-separated list of environment variables in KEY=VALUE format (overrides .env file)",
+    help="Comma-separated list of environment variables in KEY=VALUE format",
 )
 @click.option(
     "--labels",
@@ -265,7 +229,6 @@ def deploy_agent_engine_app(
     entrypoint_module: str,
     entrypoint_object: str,
     requirements_file: str,
-    env_file: str | None,
     set_env_vars: str | None,
     labels: str | None,
     service_account: str | None,
@@ -281,31 +244,17 @@ def deploy_agent_engine_app(
     logging.basicConfig(level=logging.INFO)
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
-    # Determine app directory from entrypoint module (e.g., "app.agent_engine_app" -> "app")
-    app_directory = entrypoint_module.split(".")[0]
-
-    # Load environment variables from .env file first
-    env_vars = load_env_file(env_file, app_directory)
-
-    # Parse and merge CLI environment variables (these take precedence)
-    cli_env_vars = parse_key_value_pairs(set_env_vars)
-    env_vars.update(cli_env_vars)
-
-    # Parse labels
+    # Parse CLI environment variables and labels
+    env_vars = parse_key_value_pairs(set_env_vars)
     labels_dict = parse_key_value_pairs(labels)
 
-    # Set GOOGLE_CLOUD_REGION to match deployment location
+    # Set deployment-specific environment variables
     env_vars["GOOGLE_CLOUD_REGION"] = location
-
-    # Add NUM_WORKERS from CLI argument (can be overridden via --set-env-vars)
-    if "NUM_WORKERS" not in env_vars:
-        env_vars["NUM_WORKERS"] = str(num_workers)
+    env_vars["NUM_WORKERS"] = str(num_workers)
 
     # Enable telemetry by default for Agent Engine
-    if "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" not in env_vars:
-        env_vars["GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY"] = "true"
-    if "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT" not in env_vars:
-        env_vars["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
+    env_vars.setdefault("GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY", "true")
+    env_vars.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
 
     if not project:
         _, project = google.auth.default()


### PR DESCRIPTION
## Summary
- Load .env files at runtime instead of deployment-time

## Changes
- Add load_dotenv() in agent_engine_app.py
- Remove load_env_file() function and --env-file CLI option from deploy.py
- Fix README notebooks/ folder visibility for adk_live

## Testing
Verified linting passes for adk_base, adk_live, langgraph_base, and adk_a2a_base