### PR TITLE
feat: update all agents to use gemini-3-flash-preview model

### DIFF
--- a/agent_starter_pack/agents/adk_a2a_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_a2a_base/app/agent.py
@@ -65,7 +65,7 @@ def get_current_time(query: str) -> str:
 
 root_agent = Agent(
     name="root_agent",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     description="An agent that can provide information about the weather and time.",
     instruction="You are a helpful AI assistant designed to provide accurate and useful information.",
     tools=[get_weather, get_current_time],

--- a/agent_starter_pack/agents/adk_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_base/app/agent.py
@@ -65,7 +65,7 @@ def get_current_time(query: str) -> str:
 
 root_agent = Agent(
     name="root_agent",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     instruction="You are a helpful AI assistant designed to provide accurate and useful information.",
     tools=[get_weather, get_current_time],
 )

--- a/agent_starter_pack/agents/agentic_rag/app/agent.py
+++ b/agent_starter_pack/agents/agentic_rag/app/agent.py
@@ -27,7 +27,7 @@ from {{cookiecutter.agent_directory}}.templates import format_docs
 EMBEDDING_MODEL = "text-embedding-005"
 LLM_LOCATION = "global"
 LOCATION = "us-central1"
-LLM = "gemini-3-pro-preview"
+LLM = "gemini-3-flash-preview"
 
 credentials, project_id = google.auth.default()
 os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
@@ -112,7 +112,7 @@ If you already know the answer to a question, you can respond directly without u
 
 root_agent = Agent(
     name="root_agent",
-    model="gemini-2.0-flash",
+    model="gemini-3-flash-preview",
     instruction=instruction,
     tools=[retrieve_docs],
 )

--- a/agent_starter_pack/agents/langgraph_base/app/agent.py
+++ b/agent_starter_pack/agents/langgraph_base/app/agent.py
@@ -31,7 +31,7 @@ os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
 {%- endif %}
 
-LLM = "gemini-3-pro-preview"
+LLM = "gemini-3-flash-preview"
 
 llm = ChatGoogleGenerativeAI(model=LLM, temperature=0)
 

--- a/agent_starter_pack/resources/docs/adk-cheatsheet.md
+++ b/agent_starter_pack/resources/docs/adk-cheatsheet.md
@@ -257,7 +257,7 @@ def get_current_time(city: str) -> dict:
 
 my_first_llm_agent = Agent(
     name="time_teller_agent",
-    model="gemini-3-pro-preview", # Essential: The LLM powering the agent
+    model="gemini-3-flash-preview", # Essential: The LLM powering the agent
     instruction="You are a helpful assistant that tells the current time in cities. Use the 'get_current_time' tool for this purpose.",
     description="Tells the current time in a specified city.", # Crucial for multi-agent delegation
     tools=[get_current_time] # List of callable functions/tool instances
@@ -331,7 +331,7 @@ This is the most reliable way to make an LLM produce predictable, parseable JSON
     ```python
     research_evaluator = LlmAgent(
         name="research_evaluator",
-        model="gemini-2.5-pro",
+        model="gemini-3-pro-preview",
         instruction="""You are a meticulous quality assurance analyst. Evaluate the research findings in 'section_research_findings' and be very critical.
         If you find significant gaps, assign a grade of 'fail', write a detailed comment, and generate 5-7 specific follow-up queries.
         If the research is thorough, grade it 'pass'.
@@ -357,7 +357,7 @@ This is the most reliable way to make an LLM produce predictable, parseable JSON
         from google.genai.types import ThinkingConfig
 
         agent = Agent(
-            model="gemini-3-pro-preview",
+            model="gemini-3-flash-preview",
             planner=BuiltInPlanner(
                 thinking_config=ThinkingConfig(include_thoughts=True)
             ),
@@ -372,7 +372,7 @@ This is the most reliable way to make an LLM produce predictable, parseable JSON
         from google.adk.code_executors import BuiltInCodeExecutor
         agent = Agent(
             name="code_agent",
-            model="gemini-3-pro-preview",
+            model="gemini-3-flash-preview",
             instruction="Write and execute Python code to solve math problems.",
             code_executor=BuiltInCodeExecutor() # Corrected from a list to an instance
         )
@@ -400,7 +400,7 @@ from google.adk.tools import google_search
 
 
 plan_generator = LlmAgent(
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     name="plan_generator",
     description="Generates a 4-5 line action-oriented research plan.",
     instruction=f"""
@@ -422,7 +422,7 @@ plan_generator = LlmAgent(
 This agent's `instruction` relies on data placed in `session.state` by previous agents.
 ```python
 report_composer = LlmAgent(
-    model="gemini-2.5-pro",
+    model="gemini-3-pro-preview",
     name="report_composer_with_citations",
     include_contents="none", # History not needed; all data is injected.
     description="Transforms research data and a markdown outline into a final, cited report.",
@@ -492,7 +492,7 @@ from google.adk.agents import SequentialAgent, Agent
 # Agent 1: Summarizes a document and saves to state
 summarizer = Agent(
     name="DocumentSummarizer",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     instruction="Summarize the provided document in 3 sentences.",
     output_key="document_summary" # Output saved to session.state['document_summary']
 )
@@ -500,7 +500,7 @@ summarizer = Agent(
 # Agent 2: Generates questions based on the summary from state
 question_generator = Agent(
     name="QuestionGenerator",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     instruction="Generate 3 comprehension questions based on this summary: {document_summary}",
     # 'document_summary' is dynamically injected from session.state
 )
@@ -527,7 +527,7 @@ fetch_social_sentiment = Agent(name="SentimentAnalyzer", ..., output_key="sentim
 # Agent to merge results (runs after ParallelAgent, usually in a SequentialAgent)
 merger_agent = Agent(
     name="ReportGenerator",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     instruction="Combine stock data: {stock_data}, news: {news_data}, and sentiment: {sentiment_data} into a market report."
 )
 
@@ -695,7 +695,7 @@ research_pipeline = SequentialAgent(
 # The top-level agent that interacts with the user.
 interactive_planner_agent = LlmAgent(
     name="interactive_planner_agent",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     description="The primary research assistant. It collaborates with the user to create a research plan, and then executes it upon approval.",
     instruction="""
     You are a research planning assistant. Your workflow is:
@@ -812,12 +812,12 @@ ADK's model flexibility allows integrating various LLMs for different needs.
 *   **AI Studio (Easy Start)**:
     *   Set `GOOGLE_API_KEY="YOUR_API_KEY"` (environment variable).
     *   Set `GOOGLE_GENAI_USE_VERTEXAI="False"`.
-    *   Model strings: `"gemini-3-pro-preview"`, `"gemini-2.5-pro"`, etc.
+    *   Model strings: `"gemini-3-flash-preview"`, `"gemini-3-pro-preview"`, etc.
 *   **Vertex AI (Production)**:
     *   Authenticate via `gcloud auth application-default login` (recommended).
     *   Set `GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`, `GOOGLE_CLOUD_LOCATION="your-region"` (environment variables).
     *   Set `GOOGLE_GENAI_USE_VERTEXAI="True"`.
-    *   Model strings: `"gemini-3-pro-preview"`, `"gemini-2.5-pro"`, or full Vertex AI endpoint resource names for specific deployments.
+    *   Model strings: `"gemini-3-flash-preview"`, `"gemini-3-pro-preview"`, or full Vertex AI endpoint resource names for specific deployments.
 
 ### 6.2 Other Cloud & Proprietary Models via LiteLLM
 

--- a/docs/remote-templates/creating-remote-templates.md
+++ b/docs/remote-templates/creating-remote-templates.md
@@ -79,7 +79,7 @@ def get_greeting(name: str = "World") -> str:
 
 root_agent = Agent(
     name="root_agent",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     instruction="You are a helpful AI assistant. Use your tools to answer questions.",
     tools=[get_greeting],
 )

--- a/llm.txt
+++ b/llm.txt
@@ -316,7 +316,7 @@ Before finalizing any `new_string` for a `replace` operation, meticulously verif
     ```python
     root_agent = Agent(
         name="root_agent",
-        model="gemini-3-pro-preview",
+        model="gemini-3-flash-preview",
         instruction="You are a helpful AI assistant."
     )
     ```
@@ -332,7 +332,7 @@ Before finalizing any `new_string` for a `replace` operation, meticulously verif
     ```python
     root_agent = Agent(
         name="recipe_suggester", # OK, related to new purpose
-        model="gemini-3-pro-preview", # MUST be preserved
+        model="gemini-3-flash-preview", # MUST be preserved
         instruction="You are a recipe suggester." # OK, the direct target
     )
     ```
@@ -350,7 +350,7 @@ Before finalizing any `new_string` for a `replace` operation, meticulously verif
     *   **Avoid `make playground`** unless specifically instructed; it is designed for human interaction. Focus on programmatic testing.
 
 *   **Model Selection:**
-    *   **When using Gemini, prefer modern model families** for optimal performance and capabilities: "gemini-2.5-pro", "gemini-2.5-flash", and "gemini-3-pro-preview"
+    *   **When using Gemini, prefer modern model families** for optimal performance and capabilities: "gemini-2.5-pro", "gemini-2.5-flash", and "gemini-3-flash-preview"
 
 *   **Running Python Commands:**
     *   Always use `uv` to execute Python commands within this repository (e.g., `uv run run_agent.py`).

--- a/tests/integration/test_agent_directory_functionality.py
+++ b/tests/integration/test_agent_directory_functionality.py
@@ -71,7 +71,7 @@ def greet(name: str = "World") -> str:
 
 root_agent = Agent(
     name="test_agent",
-    model="gemini-3-pro-preview",
+    model="gemini-3-flash-preview",
     instruction="You are a helpful assistant.",
     tools=[greet],
 )

--- a/tests/integration/test_pipeline_parity.py
+++ b/tests/integration/test_pipeline_parity.py
@@ -235,7 +235,7 @@ Respond with a JSON object containing:
                 }
 
                 response = self.client.models.generate_content(
-                    model="gemini-3-pro-preview",
+                    model="gemini-3-flash-preview",
                     contents=prompt,
                     config=types.GenerateContentConfig(
                         temperature=0,


### PR DESCRIPTION
## Summary
- Switch default model from `gemini-3-pro-preview` to `gemini-3-flash-preview` across all agent templates
- Update documentation examples and tests to reflect the new default

## Changes
- **adk_base**: Updated model to gemini-3-flash-preview
- **adk_a2a_base**: Updated model to gemini-3-flash-preview
- **agentic_rag**: Updated both LLM constant and root_agent model
- **langgraph_base**: Updated LLM constant
- **Documentation**: Updated adk-cheatsheet.md, llm.txt, and remote templates guide
- **Tests**: Updated test fixtures to use new model

Note: `adk_live` was intentionally not changed as it uses `gemini-live-2.5-flash-native-audio`, a specialized model for live audio streaming.