### PR TITLE
docs: clarify A2A Inspector connection URL in README (#563)

### DIFF
--- a/agent_starter_pack/base_template/README.md
+++ b/agent_starter_pack/base_template/README.md
@@ -132,7 +132,7 @@ The [A2A Inspector](https://github.com/a2aproject/a2a-inspector) provides the fo
    make inspector
    ```
 
-3. Open http://localhost:5001 and connect to `http://localhost:8000/a2a/app/.well-known/agent-card.json`
+3. Open http://localhost:5001 and connect to `http://localhost:8000/a2a/{{cookiecutter.agent_directory}}/.well-known/agent-card.json`
 {%- else %}
 
 > **Note:** For Agent Engine deployments, local testing with A2A endpoints requires deployment first, as `make playground` uses the ADK web interface. For local development, use `make playground`. To test A2A protocol compliance, follow the Remote Testing instructions below.


### PR DESCRIPTION
Update docs based on comments left here: https://github.com/GoogleCloudPlatform/agent-starter-pack/issues/563