### PR TITLE
refactor: use public API import for ADK App class

### DIFF
--- a/agent_starter_pack/agents/adk_a2a_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_a2a_base/app/agent.py
@@ -17,7 +17,7 @@ import datetime
 from zoneinfo import ZoneInfo
 
 from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 from google.adk.models import Gemini
 from google.genai import types
 {%- if not cookiecutter.use_google_api_key %}

--- a/agent_starter_pack/agents/adk_base/app/agent.py
+++ b/agent_starter_pack/agents/adk_base/app/agent.py
@@ -17,7 +17,7 @@ import datetime
 from zoneinfo import ZoneInfo
 
 from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 from google.adk.models import Gemini
 from google.genai import types
 {%- if not cookiecutter.use_google_api_key %}

--- a/agent_starter_pack/agents/adk_live/app/agent.py
+++ b/agent_starter_pack/agents/adk_live/app/agent.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 from google.adk.models import Gemini
 from google.genai import types
 {%- if not cookiecutter.use_google_api_key %}

--- a/agent_starter_pack/agents/agentic_rag/app/agent.py
+++ b/agent_starter_pack/agents/agentic_rag/app/agent.py
@@ -17,7 +17,7 @@ import os
 import google
 import vertexai
 from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 from google.adk.models import Gemini
 from google.genai import types
 from langchain_google_vertexai import VertexAIEmbeddings

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -783,8 +783,8 @@ def _inject_app_object_if_missing(
             )
             # Add import and app object at the end of the file
             content = content.rstrip()
-            if "from google.adk.apps.app import App" not in content:
-                content += "\n\nfrom google.adk.apps.app import App\n"
+            if "from google.adk.apps import App" not in content:
+                content += "\n\nfrom google.adk.apps import App\n"
             content += f'\napp = App(root_agent=root_agent, name="{agent_directory}")\n'
 
             # Write the modified content back
@@ -845,7 +845,7 @@ Edit root_agent.yaml to modify your agent configuration.
 from pathlib import Path
 
 from google.adk.agents import config_agent_utils
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 _AGENT_DIR = Path(__file__).parent
 root_agent = config_agent_utils.from_config(str(_AGENT_DIR / "root_agent.yaml"))

--- a/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/agent_engine_app.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/agent_engine_app.py
@@ -31,7 +31,7 @@ from dotenv import load_dotenv
 {%- if cookiecutter.is_a2a %}
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.a2a.utils.agent_card_builder import AgentCardBuilder
-from google.adk.apps.app import App
+from google.adk.apps import App
 {%- endif %}
 from google.adk.artifacts import GcsArtifactService, InMemoryArtifactService
 {%- if cookiecutter.is_a2a %}

--- a/agent_starter_pack/resources/docs/adk-cheatsheet.md
+++ b/agent_starter_pack/resources/docs/adk-cheatsheet.md
@@ -456,7 +456,7 @@ report_composer = LlmAgent(
 Wraps the `root_agent` to enable production-grade runtime features that an `Agent` cannot handle alone.
 
 ```python
-from google.adk.apps.app import App
+from google.adk.apps import App
 from google.adk.agents.context_cache_config import ContextCacheConfig
 from google.adk.apps.events_compaction_config import EventsCompactionConfig
 from google.adk.apps.resumability_config import ResumabilityConfig

--- a/tests/cli/commands/test_enhance.py
+++ b/tests/cli/commands/test_enhance.py
@@ -350,7 +350,7 @@ class TestEnhanceAgentEngineAppGeneration:
             # Create appropriate agent.py content based on template type
             if "adk" in base_template or base_template == "agentic_rag":
                 agent_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 root_agent = Agent(
     name="test_agent",
@@ -429,7 +429,7 @@ agent = RunnablePassthrough()
             agent_dir.mkdir()
             agent_file = agent_dir / "agent.py"
             agent_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 root_agent = Agent(
     name="test_agent",
@@ -620,7 +620,7 @@ root_agent = Agent(
     model="gemini-2.0-flash-001",
 )
 
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 app = App(root_agent=root_agent, name="app")
 """
@@ -639,7 +639,7 @@ app = App(root_agent=root_agent, name="app")
             agent_file = agent_dir / "agent.py"
 
             agent_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 root_agent = Agent(
     name="test_agent",
@@ -762,7 +762,7 @@ root_agent = Agent(
     model="gemini-2.0-flash-001",
 )
 
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 app = App(root_agent=root_agent, name="app")
 """
@@ -1079,7 +1079,7 @@ root_agent = Agent(
 
             # Verify app object was injected
             modified_content = agent_file.read_text()
-            assert "from google.adk.apps.app import App" in modified_content, (
+            assert "from google.adk.apps import App" in modified_content, (
                 f"Expected App import to be injected for {base_template}"
             )
             assert 'app = App(root_agent=root_agent, name="app")' in modified_content, (
@@ -1125,7 +1125,7 @@ agent = RunnablePassthrough()
 
             # Verify app object was NOT injected (langgraph doesn't need it)
             modified_content = agent_file.read_text()
-            assert "from google.adk.apps.app import App" not in modified_content, (
+            assert "from google.adk.apps import App" not in modified_content, (
                 "App import should NOT be injected for langgraph_base"
             )
 
@@ -1142,7 +1142,7 @@ agent = RunnablePassthrough()
             agent_file = agent_dir / "agent.py"
 
             agent_content = """from google.adk.agents import Agent
-from google.adk.apps.app import App
+from google.adk.apps import App
 
 root_agent = Agent(
     name="test_agent",


### PR DESCRIPTION
## Summary
- Change `from google.adk.apps.app import App` to `from google.adk.apps import App`
- Update all agent templates (adk_base, adk_live, agentic_rag, adk_a2a_base)
- Update template processing logic and deployment target files
- Update documentation and tests

## Problem
The current import `from google.adk.apps.app import App` reaches into the internal module structure of the ADK package. The ADK package explicitly re-exports `App` at the package level (`google.adk.apps`), making the shorter import the canonical form.

## Solution
Updated all occurrences to use `from google.adk.apps import App`, which:
- Matches the official ADK documentation
- Uses the public API as intended by the package authors
- Is more resilient to internal refactoring
- Is cleaner and easier to read