### PR TITLE
fix: add telemetry API to base terraform deploy services

### DIFF
--- a/agent_starter_pack/base_templates/_shared/deployment/terraform/locals.tf
+++ b/agent_starter_pack/base_templates/_shared/deployment/terraform/locals.tf
@@ -36,6 +36,7 @@ locals {
     "serviceusage.googleapis.com",
     "logging.googleapis.com",
     "cloudtrace.googleapis.com",
+    "telemetry.googleapis.com",
 {%- if cookiecutter.is_adk and cookiecutter.session_type == "cloud_sql" %}
     "sqladmin.googleapis.com",
     "secretmanager.googleapis.com"


### PR DESCRIPTION
## Summary
- Add `telemetry.googleapis.com` to `deploy_project_services` in base terraform locals.tf

## Problem
The telemetry API was only enabled in the dev environment (`dev/apis.tf`) but missing from the base terraform configuration that provisions staging and prod projects.

## Solution
Added `telemetry.googleapis.com` to the `deploy_project_services` list in `locals.tf` to ensure consistent API enablement across all environments.