### PR TITLE
fix: use correct cookiecutter variable for ASP version in Go Makefile

### DIFF
--- a/agent_starter_pack/base_templates/go/Makefile
+++ b/agent_starter_pack/base_templates/go/Makefile
@@ -194,7 +194,7 @@ build-inspector-if-needed:
 register-gemini-enterprise:
 	@PROJECT_ID=$$(gcloud config get-value project 2>/dev/null) && \
 	PROJECT_NUMBER=$$(gcloud projects describe $$PROJECT_ID --format="value(projectNumber)" 2>/dev/null) && \
-	uvx agent-starter-pack@{{cookiecutter.asp_version}} register-gemini-enterprise \
+	uvx agent-starter-pack@{{ cookiecutter.package_version }} register-gemini-enterprise \
 		--agent-card-url="https://{{cookiecutter.project_name}}-$$PROJECT_NUMBER.us-central1.run.app/.well-known/agent-card.json" \
 		--deployment-target="cloud_run" \
 		--project-number="$$PROJECT_NUMBER"


### PR DESCRIPTION
## Summary
- Fix Go Makefile template to use `package_version` instead of `asp_version`

## Problem
The `register-gemini-enterprise` target in the Go Makefile template used `{{cookiecutter.asp_version}}`, but this variable is not passed during template processing. This resulted in an empty version string:

```makefile
uvx agent-starter-pack@ register-gemini-enterprise \
```

## Solution
Changed to use `{{ cookiecutter.package_version }}` which is correctly set in `template.py:1252`, matching the Python Makefile template behavior.