### PR TITLE
fix: inject a2a_agent_url flag only when a2a sublauncher is present

### DIFF
--- a/agent_starter_pack/base_templates/go/main.go
+++ b/agent_starter_pack/base_templates/go/main.go
@@ -87,13 +87,21 @@ func main() {
 	}
 
 	args := os.Args[1:]
-	// Inject -a2a_agent_url flag for correct agent card URL
+	// Inject -a2a_agent_url flag after "a2a" sublauncher for correct agent card URL
 	// Uses APP_URL env var if set, otherwise defaults to localhost:8000 for local dev
 	appURL := os.Getenv("APP_URL")
 	if appURL == "" {
 		appURL = "http://localhost:8000"
 	}
-	args = append(args, "-a2a_agent_url", appURL)
+
+	var newArgs []string
+	for _, arg := range args {
+		newArgs = append(newArgs, arg)
+		if arg == "a2a" {
+			newArgs = append(newArgs, "-a2a_agent_url", appURL)
+		}
+	}
+	args = newArgs
 
 	l := full.NewLauncher()
 	if err = l.Execute(ctx, config, args); err != nil {


### PR DESCRIPTION
## Summary
- Fix flag injection logic in Go agent template to only inject flags for sublaunchers that support them
- Resolves error when running `make playground` or using other sublaunchers

## Problem
The Go agent template unconditionally appended the `-a2a_agent_url` flag to all launcher arguments. This caused errors when using sublaunchers that don't support this flag:

```
flag provided but not defined: -a2a_agent_url
Usage of webui:
  -api_server_address string
        ADK REST API server address...
```

Commands like `make playground` (which uses the `webui` sublauncher) would fail with this error.

## Solution
Updated `agent_starter_pack/base_templates/go/main.go` to only inject the `-a2a_agent_url` flag immediately after the `a2a` sublauncher argument. This ensures flags are associated with the correct sublauncher.

## Testing
Verified both scenarios work correctly:
- `make playground` (webui sublauncher) - starts successfully without flag errors
- `make local-backend` (a2a sublauncher) - starts successfully with injected flag