### PR TITLE
feat: enable Web UI deployment for Go agents

### DIFF
--- a/agent_starter_pack/base_templates/go/Makefile
+++ b/agent_starter_pack/base_templates/go/Makefile
@@ -61,7 +61,12 @@ local-backend:
 # ==============================================================================
 
 # Deploy the agent remotely
-# Usage: make deploy [IAP=true] [PORT=8080] - Set IAP=true to enable Identity-Aware Proxy, PORT to specify container port
+# Usage: make deploy [IAP=true] [PORT=8080]
+#   IAP=true  - Enable Identity-Aware Proxy for authenticated access (required for Web UI)
+#   PORT=8080 - Specify container port
+#
+# The deployed app includes Web UI at /ui/ - access requires IAP authentication
+# Example: make deploy IAP=true
 deploy:
 	PROJECT_ID=$$(gcloud config get-value project) && \
 	PROJECT_NUMBER=$$(gcloud projects describe $$PROJECT_ID --format="value(projectNumber)") && \

--- a/agent_starter_pack/base_templates/go/main.go
+++ b/agent_starter_pack/base_templates/go/main.go
@@ -100,6 +100,9 @@ func main() {
 		if arg == "a2a" {
 			newArgs = append(newArgs, "-a2a_agent_url", appURL)
 		}
+		if arg == "webui" {
+			newArgs = append(newArgs, "-api_server_address", appURL+"/api")
+		}
 	}
 	args = newArgs
 

--- a/agent_starter_pack/deployment_targets/cloud_run/go/Dockerfile
+++ b/agent_starter_pack/deployment_targets/cloud_run/go/Dockerfile
@@ -41,8 +41,9 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 EXPOSE 8080
 
 # Cloud Run sets PORT env var which ADK launcher reads automatically
-# Supports both REST API and A2A protocol
+# Supports REST API, A2A protocol, and Web UI
 # API endpoints: /api/run_sse, /api/apps/...
 # A2A endpoint: /a2a/invoke (JSON-RPC)
 # Agent card: /.well-known/agent-card.json
-ENTRYPOINT ["/agent", "web", "api", "a2a"]
+# Web UI: /ui/ (requires IAP for authenticated access)
+ENTRYPOINT ["/agent", "web", "api", "a2a", "webui"]


### PR DESCRIPTION
## Summary
- Add `webui` sublauncher to Dockerfile ENTRYPOINT for deployed Go apps
- Inject `-api_server_address` flag when `webui` sublauncher is present
- Update Makefile deploy documentation to explain IAP requirement

## Changes
- **Dockerfile**: ENTRYPOINT now includes `webui` alongside `api` and `a2a`
- **main.go**: Flag injection logic extended to handle `webui` sublauncher
- **Makefile**: Deploy target documentation updated with IAP instructions

## Details
Deployed Go agents now include the Web UI at `/ui/` in addition to:
- REST API at `/api/`
- A2A protocol at `/a2a/invoke`

To access the Web UI in production, deploy with IAP enabled:
```bash
make deploy IAP=true
```

The `APP_URL` environment variable is used to configure both sublaunchers:
- `a2a` receives `-a2a_agent_url` for the agent card URL
- `webui` receives `-api_server_address` for API connectivity