### PR TITLE
feat: skip E2E tests for dependency update commits

### DIFF
--- a/.cloudbuild/cd/test_e2e.yaml
+++ b/.cloudbuild/cd/test_e2e.yaml
@@ -20,18 +20,28 @@ steps:
     args:
       - "-c"
       - |
+        # Skip E2E tests for dependency updates (e.g., Dependabot PRs)
+        if [[ "${_COMMIT_MESSAGE}" == build\(deps\)* ]]; then
+          echo "Skipping E2E tests for dependency update: ${_COMMIT_MESSAGE}"
+          touch /workspace/.skip-e2e
+          exit 0
+        fi
         uv sync --dev --locked
 
-  # Run unit tests using pytest
+  # Run E2E tests using pytest
   - name: "europe-west4-docker.pkg.dev/production-ai-template/starter-pack/e2e-tests"
     id: e2e-tests
     entrypoint: /bin/bash
     args:
       - "-c"
       - |
+        if [ -f /workspace/.skip-e2e ]; then
+          echo "Skipping E2E tests - dependency update commit"
+          exit 0
+        fi
         GH_TOKEN=$$GITHUB_PAT uv run pytest tests/cicd/test_e2e_deployment.py -v
     secretEnv: ['GITHUB_PAT', 'GITHUB_APP_INSTALLATION_ID']
-    
+
 availableSecrets:
   secretManager:
   - versionName: projects/${_SECRETS_PROJECT_ID}/secrets/github-pat/versions/latest
@@ -51,3 +61,4 @@ options:
 timeout: 43200s
 substitutions:
   _SECRETS_PROJECT_ID: 'asp-e2e-vars'
+  _COMMIT_MESSAGE: ''

--- a/.cloudbuild/cd/test_gemini_enterprise.yaml
+++ b/.cloudbuild/cd/test_gemini_enterprise.yaml
@@ -20,6 +20,12 @@ steps:
     args:
       - "-c"
       - |
+        # Skip tests for dependency updates (e.g., Dependabot PRs)
+        if [[ "${_COMMIT_MESSAGE}" == build\(deps\)* ]]; then
+          echo "Skipping tests for dependency update: ${_COMMIT_MESSAGE}"
+          touch /workspace/.skip-e2e
+          exit 0
+        fi
         uv sync --dev --locked
 
   # Set gcloud project to dev environment
@@ -29,6 +35,10 @@ steps:
     args:
       - "-c"
       - |
+        if [ -f /workspace/.skip-e2e ]; then
+          echo "Skipping - dependency update commit"
+          exit 0
+        fi
         gcloud config set project ${_E2E_DEV_PROJECT}
 
   # Fetch identity token for Cloud Run authentication
@@ -38,6 +48,10 @@ steps:
     args:
       - "-c"
       - |
+        if [ -f /workspace/.skip-e2e ]; then
+          echo "Skipping - dependency update commit"
+          exit 0
+        fi
         gcloud auth print-identity-token -q > /workspace/id_token.txt
 
   # Run Gemini Enterprise registration test
@@ -47,6 +61,10 @@ steps:
     args:
       - "-c"
       - |
+        if [ -f /workspace/.skip-e2e ]; then
+          echo "Skipping Gemini Enterprise test - dependency update commit"
+          exit 0
+        fi
         export ID_TOKEN=$(cat /workspace/id_token.txt)
         uv run pytest tests/cicd/test_gemini_enterprise_registration.py -v
     secretEnv: ['GEMINI_ENTERPRISE_APP_ID']
@@ -62,3 +80,5 @@ options:
   env:
     - "RUN_GEMINI_ENTERPRISE_TEST=1"
 timeout: 3600s  # 1 hour timeout
+substitutions:
+  _COMMIT_MESSAGE: ''

--- a/.cloudbuild/terraform/build_triggers.tf
+++ b/.cloudbuild/terraform/build_triggers.tf
@@ -448,6 +448,7 @@ resource "google_cloudbuild_trigger" "main_e2e_deployment_test" {
     _E2E_STAGING_PROJECT    = var.e2e_test_project_mapping.staging
     _E2E_PROD_PROJECT       = var.e2e_test_project_mapping.prod
     _SECRETS_PROJECT_ID     = "asp-e2e-vars"
+    _COMMIT_MESSAGE         = "$(push.head_commit.message)"
   }
 }
 
@@ -579,5 +580,6 @@ resource "google_cloudbuild_trigger" "main_e2e_gemini_enterprise_test" {
 
   substitutions = {
     _E2E_DEV_PROJECT = var.e2e_test_project_mapping.dev
+    _COMMIT_MESSAGE  = "$(push.head_commit.message)"
   }
 }


### PR DESCRIPTION
## Summary
- Skip E2E and Gemini Enterprise tests when commit message starts with `build(deps)`
- Uses Cloud Build payload binding to pass commit message as substitution variable
- Reduces unnecessary CI costs for Dependabot PRs

## Changes
- Add `_COMMIT_MESSAGE = "$(push.head_commit.message)"` substitution to E2E triggers
- Update `test_e2e.yaml` to check commit message and skip if dependency update
- Update `test_gemini_enterprise.yaml` with same skip logic