### PR TITLE
docs: update default video to AI with Surya tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Visit our [documentation site](https://googlecloudplatform.github.io/agent-start
 
 ### Video Walkthrough:
 
-- **[Exploring the Agent Starter Pack](https://www.youtube.com/watch?v=9zqwym-N3lg)**: A comprehensive tutorial demonstrating how to rapidly deploy AI Agents using the Agent Starter Pack, covering architecture, templates, and step-by-step deployment.
+- **[From Demo to Production with Agent Starter Pack](https://www.youtube.com/watch?v=mtJMYgJkTt8)**: Learn how the Agent Starter Pack acts as an Automated Architect, building the professional infrastructure for your AI project in seconds. Covers why most AI projects fail at deployment and how ASP automates Terraform, CI/CD, and observability.
 
 - **[6-minute introduction](https://www.youtube.com/live/eZ-8UQ_t4YM?feature=shared&t=2791)** (April 2024): Explaining the Agent Starter Pack and demonstrating its key features. Part of the Kaggle GenAI intensive course.
 

--- a/docs/guide/video-tutorials.md
+++ b/docs/guide/video-tutorials.md
@@ -1,8 +1,14 @@
 # Video Tutorials
 
-## Exploring Agent Starter Pack (April 2025)
+## From Demo to Production with Agent Starter Pack (January 2026)
 
-This comprehensive tutorial demonstrates how to rapidly deploy AI Agents using the Agent Starter Pack. We cover the architecture, detail the templates and their usage, showcase a live demo, and guide you through template-based deployment from start to finish.
+Building an agent demo is easy—shipping it is the nightmare. This video by AI with Surya shows how the Agent Starter Pack acts as an Automated Architect, building the professional "outer shell" for your AI project in seconds. Covers the 60-second demo, why most AI projects fail at deployment, and how ASP automates Terraform, CI/CD, and observability.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/mtJMYgJkTt8?si=K4kHS0G463VBGons" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## Agent Starter Pack Deep Dive (April 2025)
+
+A comprehensive tutorial demonstrating how to rapidly deploy AI Agents using the Agent Starter Pack, covering architecture, templates, and step-by-step deployment.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/9zqwym-N3lg?si=K4kHS0G463VBGons" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ hero:
       link: /guide/development-guide
     - theme: alt
       text: Watch Demo Video
-      link: https://www.youtube.com/watch?v=9zqwym-N3lg
+      link: https://www.youtube.com/watch?v=mtJMYgJkTt8
 
 features:
   - icon: ⚡️


### PR DESCRIPTION
## Summary
- Update default video to "From Demo to Production with Agent Starter Pack" by AI with Surya
- Add previous default video as second entry in video tutorials page

## Changes
- **README.md**: Updated featured video link and description
- **docs/index.md**: Updated "Watch Demo Video" button link
- **docs/guide/video-tutorials.md**: New video as #1, previous video moved to #2