### PR TITLE
fix: add deployment_target to conditional config for adk_live service.tf exclusion

### DIFF
--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -1630,6 +1630,7 @@ def process_template(
             # Apply conditional file logic (Windows-compatible replacement for Jinja2 filenames)
             conditional_config = {
                 "agent_name": agent_name,
+                "deployment_target": deployment_target,
                 "cicd_runner": cicd_runner or "google_cloud_build",
                 "is_adk": "adk" in tags,
                 "is_adk_live": "adk_live" in tags,


### PR DESCRIPTION
## Summary
- Fix adk_live agent_engine deployment failures
- Add missing deployment_target key to conditional_config dict
- Enable proper exclusion of service.tf files for adk_live agents

## Problem
E2E tests were failing when deploying adk_live agents to agent_engine:
```
Error: Cannot update the agent engine deployed with spec.deployment_source 
to use spec.package_spec
```

The conditional logic to exclude service.tf files for adk_live + agent_engine 
was never triggering because the deployment_target key was missing from the 
conditional_config dict in template.py.

## Solution
Added "deployment_target": deployment_target to the conditional_config dict 
at line 1633. This allows the existing _exclude_adk_live_agent_engine 
condition to properly evaluate and exclude service.tf files for adk_live 
agents, preventing Terraform from creating conflicting agent engine resources.