### PR TITLE
Use aiplatform.user role for agent identity permissions

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -148,7 +148,7 @@ def setup_agent_identity(client: Any, project: str, display_name: str) -> Any:
     )
 
     roles = [
-        "roles/aiplatform.expressUser",
+        "roles/aiplatform.user",
         "roles/serviceusage.serviceUsageConsumer",
         "roles/browser",
         "roles/cloudapiregistry.viewer",


### PR DESCRIPTION
## Summary
- Update agent identity IAM role from `roles/aiplatform.expressUser` to `roles/aiplatform.user`
- Provides broader Vertex AI service access for agents with identity-based permissions

## Problem
The current implementation grants `roles/aiplatform.expressUser` which is designed for simplified Express Mode usage with API keys. This role has limited capabilities compared to the full Vertex AI user role.

## Solution
Changed the IAM role assignment in `deploy.py:151` to use `roles/aiplatform.user` instead. This role provides:
- Access to core generative AI features (same as expressUser)
- Additional permissions to predict with models
- Broader Vertex AI service capabilities for more complex agent workflows

The change affects the `setup_agent_identity()` function which automatically configures IAM permissions when deploying agents with the `--agent-identity` flag.