### PR TITLE
fix: use Locust client for session creation in Cloud Run load test

### DIFF
--- a/agent_starter_pack/deployment_targets/cloud_run/python/tests/load_test/load_test.py
+++ b/agent_starter_pack/deployment_targets/cloud_run/python/tests/load_test/load_test.py
@@ -219,7 +219,6 @@ from locust import HttpUser, between, task
 {%- elif cookiecutter.is_adk %}
 import uuid
 
-import requests
 from locust import HttpUser, between, task
 {%- else %}
 
@@ -287,12 +286,10 @@ class ChatStreamUser(HttpUser):
         user_id = f"user_{uuid.uuid4()}"
         session_data = {"state": {"preferred_language": "English", "visit_count": 1}}
 
-        session_url = f"{self.client.base_url}/apps/{{cookiecutter.agent_directory}}/users/{user_id}/sessions"
-        session_response = requests.post(
-            session_url,
+        session_response = self.client.post(
+            f"/apps/{{cookiecutter.agent_directory}}/users/{user_id}/sessions",
             headers=headers,
             json=session_data,
-            timeout=10,
         )
 
         # Get session_id from response


### PR DESCRIPTION
## Summary
- Use `self.client.post()` instead of `requests.post()` for session creation in Cloud Run ADK load tests
- Remove unused `requests` import

## Problem
The load test creates sessions using `requests.post()` (a standalone HTTP client) but sends chat messages using Locust's `self.client.post()`. With Cloud Run's session affinity:

1. Session creation → goes to instance A
2. Chat request via Locust client → may go to instance B
3. Instance B has no knowledge of the session → 404

## Solution
Use the same Locust HTTP client (`self.client`) for both session creation and chat requests, ensuring consistent session affinity cookies across all requests.