### PR TITLE
feat: add display_name support and rebrand langgraph as custom_a2a

### DIFF
--- a/agent_starter_pack/agents/langgraph/.template/templateconfig.yaml
+++ b/agent_starter_pack/agents/langgraph/.template/templateconfig.yaml
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: "ReAct agent with A2A protocol"
+display_name: "custom_a2a"
+description: "Bring your own framework, A2A-ready"
 settings:
   requires_data_ingestion: false
   deployment_targets: ["agent_engine", "cloud_run"]

--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -1074,7 +1074,7 @@ def display_agent_selection(deployment_target: str | None = None) -> str:
     # Group headers for display
     GROUP_HEADERS = {
         ("python", "adk"): "🐍 Python (ADK)",
-        ("python", "langgraph"): "🦜 Python (LangGraph)",
+        ("python", "langgraph"): "🐍 Python (A2A)",
         ("go", "adk"): "🔵 Go (ADK)",
     }
 
@@ -1090,8 +1090,9 @@ def display_agent_selection(deployment_target: str | None = None) -> str:
             header = GROUP_HEADERS.get(agent_group, "Other")
             console.print(f"\n  [bold cyan]{header}[/]")
 
-        # Align agent names for cleaner display
-        name_padded = agent["name"].ljust(14)
+        # Align agent names for cleaner display (use display_name if available)
+        display_name = agent.get("display_name", agent["name"])
+        name_padded = display_name.ljust(14)
         console.print(
             f"     {num}. [bold]{name_padded}[/] [dim]{agent['description']}[/]"
         )

--- a/agent_starter_pack/cli/commands/list.py
+++ b/agent_starter_pack/cli/commands/list.py
@@ -199,5 +199,6 @@ def list_agents(adk: bool, source: str | None) -> None:
     table.add_column("Description")
 
     for i, (_, agent) in enumerate(agents.items()):
-        table.add_row(str(i + 1), agent["name"], agent["description"])
+        display_name = agent.get("display_name", agent["name"])
+        table.add_row(str(i + 1), display_name, agent["description"])
     console.print(table)

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -56,6 +56,8 @@ from .remote_template import (
 AGENT_ALIASES: dict[str, str] = {
     "adk_base": "adk",
     "langgraph_base": "langgraph",
+    "custom": "langgraph",
+    "custom_a2a": "langgraph",
     "adk_a2a_base": "adk_a2a",
     "adk_base_go": "adk_go",
 }
@@ -402,10 +404,12 @@ def get_available_agents(deployment_target: str | None = None) -> dict:
                         framework = "other"
 
                     description = config.get("description", "No description available")
+                    display_name = config.get("display_name", agent_name)
                     priority = PRIORITY_ORDER.get(agent_name, 100)
 
                     agent_info = {
                         "name": agent_name,
+                        "display_name": display_name,
                         "description": description,
                         "language": language,
                         "framework": framework,


### PR DESCRIPTION
## Summary
- Add `display_name` field support for agent templates
- Rebrand langgraph template as "custom_a2a" for better discoverability
- Add aliases for backward compatibility

## Changes
- **templateconfig.yaml**: Added `display_name: "custom_a2a"` and updated description to "Bring your own framework, A2A-ready"
- **create.py**: Use `display_name` when available in agent selection menu; changed group header from "🦜 Python (LangGraph)" to "🐍 Python (A2A)"
- **list.py**: Use `display_name` when available in agent list table
- **template.py**: Added `custom` and `custom_a2a` aliases pointing to `langgraph`; extract `display_name` from config

## Rationale
The langgraph template serves as a "bring your own framework" option. Rebranding it as `custom_a2a` makes this purpose clearer while maintaining backward compatibility through aliases.