### PR TITLE
fix: pass display_name when creating agent with identity

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -164,7 +164,10 @@ def setup_agent_identity(client: Any, project: str, display_name: str) -> Any:
     """Create agent with identity and grant required IAM roles."""
     click.echo(f"\n🔧 Creating agent identity for: {display_name}")
     agent = client.agent_engines.create(
-        config={"identity_type": IdentityType.AGENT_IDENTITY}
+        config={
+            "identity_type": IdentityType.AGENT_IDENTITY,
+            "display_name": display_name,
+        }
     )
 
     roles = [


### PR DESCRIPTION
## Summary
- Pass `display_name` in the initial agent create call when using `--agent-identity`
- Ensures agents are properly named from creation rather than having empty names

## Problem
When deploying with `--agent-identity`, the `setup_agent_identity` function only passed `identity_type` to the initial create call:

```python
agent = client.agent_engines.create(
    config={"identity_type": IdentityType.AGENT_IDENTITY}
)
```

This resulted in agents being created with empty display names, even though the `display_name` parameter was received by the function.

## Solution
Include `display_name` in the config during the initial create call:

```python
agent = client.agent_engines.create(
    config={
        "identity_type": IdentityType.AGENT_IDENTITY,
        "display_name": display_name,
    }
)
```