### PR TITLE
refactor: consolidate agent group headers by language

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -1077,22 +1077,21 @@ def display_agent_selection(deployment_target: str | None = None) -> str:
 
     # Group headers for display
     GROUP_HEADERS = {
-        ("python", "adk"): "\U0001f40d Python (ADK)",
-        ("python", "langgraph"): "\U0001f99c Python (LangGraph)",
-        ("go", "adk"): "\U0001f535 Go (ADK)",
-        ("java", "adk"): "\u2615\ufe0f Java (ADK)",
+        "python": "\U0001f40d Python",
+        "go": "\U0001f535 Go",
+        "java": "\u2615\ufe0f Java",
     }
 
     console.print("\n> Please select an agent to get started:")
 
     current_group = None
     for num, agent in agents.items():
-        agent_group = (agent["language"], agent["framework"])
+        agent_group = agent["language"]
 
         # Print group header when transitioning to a new group
         if agent_group != current_group:
             current_group = agent_group
-            header = GROUP_HEADERS.get(agent_group, "Other")
+            header = GROUP_HEADERS.get(agent_group, "\U0001f527 Other")
             console.print(f"\n  [bold cyan]{header}[/]")
 
         # Align agent names for cleaner display (use display_name if available)

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -458,16 +458,15 @@ def get_available_agents(deployment_target: str | None = None) -> dict:
                 except Exception as e:
                     logging.warning(f"Could not load agent from {agent_dir}: {e}")
 
-    # Define group order: Python ADK, Python LangGraph, Go ADK, Java ADK, Other
+    # Define group order by language: Python, Go, Java, Other
     GROUP_ORDER = {
-        ("python", "adk"): 0,
-        ("python", "langgraph"): 1,
-        ("go", "adk"): 2,
-        ("java", "adk"): 3,
+        "python": 0,
+        "go": 1,
+        "java": 2,
     }
 
     def sort_key(agent: dict) -> tuple:
-        group = (agent["language"], agent["framework"])
+        group = agent["language"]
         group_order = GROUP_ORDER.get(group, 99)
         return (group_order, agent["priority"], agent["name"])
 


### PR DESCRIPTION
  ## Summary                                                                                                                                               
  - Simplify agent selection menu by grouping templates by language only                                                                                   
  - Remove framework suffixes (ADK, LangGraph) from group headers since template names are self-explanatory                                                
                                                                                                                                                           
  ## Before                                                                                                                                                
  🐍 Python (ADK)                                                                                                                                          
  🐍 Python (LangGraph)                                                                                                                                    
  🔵 Go (ADK)                                                                                                                                              
                                                                                                                                                           
  ## After                                                                                                                                                 
  🐍 Python                                                                                                                                                
  🔵 Go                                                                                                                                                    
  ☕️ Java