### PR TITLE
fix: bump spring-boot-starter-test version for java 25 compatibility

### DIFF
--- a/agent_starter_pack/base_templates/go/README.md
+++ b/agent_starter_pack/base_templates/go/README.md
@@ -97,7 +97,6 @@ make install && make playground
 | `uvx agent-starter-pack extract` | Extract minimal, shareable version of your agent |
 
 ---
-{%- endif %}
 {%- if not extracted|default(false) %}
 
 ## Development

--- a/agent_starter_pack/base_templates/java/pom.xml
+++ b/agent_starter_pack/base_templates/java/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>3.4.1</version>
+      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
- bump `spring-boot-starter-test` version for java 25 compatibility
- fix breaking change in go readme