### PR TITLE
fix: fix flaky pr-test-makefile issue

### DIFF
--- a/agent_starter_pack/base_templates/python/pyproject.toml
+++ b/agent_starter_pack/base_templates/python/pyproject.toml
@@ -92,7 +92,7 @@ deprecated = "ignore"
 
 [tool.codespell]
 ignore-words-list = "rouge"
-skip = "./locust_env/*,uv.lock,.venv,./frontend,**/*.ipynb"
+skip = "./locust_env/*,uv.lock,.venv,./frontend,**/*.ipynb,**/package-lock.json"
 
 
 [build-system]


### PR DESCRIPTION
Skips `package-lock.json` in codespell to fix flaky `pr-test-makefile` CI