### PR TITLE
fix(docs): resolve Vitepress dead links to observability guide

### DIFF
--- a/docs/guide/development-guide.md
+++ b/docs/guide/development-guide.md
@@ -179,7 +179,7 @@ Track your agent's performance using integrated observability tools. OpenTelemet
 *   **Cloud Trace**: Inspect request flows and analyze latencies for GenAI operations at: `https://console.cloud.google.com/traces/list?project=YOUR_PROJECT_ID`
 *   **Visualization** (Optional): Connect your BigQuery data to BI tools for custom dashboards.
 
-➡️ For complete setup instructions, example queries, and testing in dev, see the [Observability Guide](./observability.md).
+➡️ For complete setup instructions, example queries, and testing in dev, see the [Observability Guide](./observability/).
 
 ## 4. Keeping Your Project Up-to-Date
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -40,7 +40,7 @@ cd <your-project> && make install && make playground
 See the [Development Guide](/guide/development-guide) for the full workflow, or jump to:
 - [Data Ingestion](/guide/data-ingestion) - Add RAG capabilities
 - [Deployment Guide](/guide/deployment) - Deploy to Google Cloud
-- [Observability](/guide/observability) - Monitor your agent
+- [Observability](/guide/observability/) - Monitor your agent
 
 ---
 


### PR DESCRIPTION
## Summary
- Update observability guide links to point explicitly to `index.md`