### PR TITLE
fix(docs): use relative path for observability image

### DIFF
--- a/docs/guide/observability/cloud-trace.md
+++ b/docs/guide/observability/cloud-trace.md
@@ -1,6 +1,6 @@
 # Agent Telemetry Events (Cloud Trace)
 
-![monitoring_flow](/docs/images/observability.png)
+![monitoring_flow](../../images/observability.png)
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Fix broken Vitepress build caused by absolute image path in `cloud-trace.md`
- Change `/docs/images/observability.png` to relative path `../../images/observability.png`

## Problem
The Vitepress build fails because Rollup cannot resolve the absolute path `/docs/images/observability.png` referenced in `docs/guide/observability/cloud-trace.md`.

## Solution
- Use a relative path (`../../images/observability.png`) consistent with how all other docs reference images