### PR TITLE
fix: default cicd_runner to skip when not specified with --auto-approve

### DIFF
--- a/agent_starter_pack/cli/commands/enhance.py
+++ b/agent_starter_pack/cli/commands/enhance.py
@@ -665,12 +665,13 @@ def enhance(
         console.print("> Debug mode enabled")
         logging.debug("Starting enhance command in debug mode")
 
-    # Validate required options for programmatic invocation
+    # Default cicd_runner to "skip" for programmatic invocation
     if auto_approve and not cicd_runner:
-        raise click.ClickException(
-            "When using --auto-approve (-y), you must specify --cicd-runner.\n"
-            "Example: uvx agent-starter-pack enhance . -y --cicd-runner github_actions"
+        console.print(
+            "[yellow]Warning: --cicd-runner not specified with --auto-approve. "
+            "Defaulting to 'skip'. Use --cicd-runner to configure CI/CD.[/yellow]"
         )
+        cicd_runner = "skip"
 
     # Handle --adk shortcut
     if adk:


### PR DESCRIPTION
## Summary
- `enhance --auto-approve` no longer requires `--cicd-runner`
- Defaults to `skip` with a warning when not specified
- Enables incremental workflows: add deployment first, CI/CD later

## Context
When using `enhance` programmatically (e.g. from an MCP server), users may want to add just deployment without deciding on CI/CD yet. Previously this required `--cicd-runner skip` explicitly, or the command would error out.