### PR TITLE
docs: mention MCP tool alternative for enhance command

### DIFF
--- a/agent_starter_pack/base_templates/python/GEMINI.md
+++ b/agent_starter_pack/base_templates/python/GEMINI.md
@@ -841,6 +841,7 @@ Note: `setup-cicd` automatically initializes git if needed.
      --cicd-runner github_actions \
      -y -s
    ```
+   Or use the equivalent MCP tool call (`enhance_project`) if available.
 
 2. Ensure you're logged in to GitHub CLI:
    ```bash


### PR DESCRIPTION
## Summary
- Add note in GEMINI.md that the `enhance_project` MCP tool call can be used as an alternative to the CLI `enhance` command when adding Terraform/CI-CD files to a prototype project