### PR TITLE
fix: remove deploy/backend targets when deployment_target is none

### DIFF
--- a/agent_starter_pack/base_templates/python/Makefile
+++ b/agent_starter_pack/base_templates/python/Makefile
@@ -256,6 +256,7 @@ build-inspector-if-needed:
 		cd tools/a2a-inspector/frontend && npm run build; \
 	fi
 {%- endif %}
+{%- if cookiecutter.deployment_target != 'none' %}
 
 # ==============================================================================
 # Backend Deployment Targets
@@ -296,13 +297,11 @@ deploy:
 		--entrypoint-object=agent_engine \
 		--requirements-file={{cookiecutter.agent_directory}}/app_utils/.requirements.txt \
 		$(if $(AGENT_IDENTITY),--agent-identity)
-{%- elif cookiecutter.deployment_target == 'none' %}
-	@echo "No deployment target configured."
-	@echo "Run 'uvx agent-starter-pack enhance' to add a deployment target."
 {%- endif %}
 
 # Alias for 'make deploy' for backward compatibility
 backend: deploy
+{%- endif %}
 
 {%- if cookiecutter.cicd_runner != 'skip' %}
 


### PR DESCRIPTION
## Summary
- Remove `make deploy` and `make backend` targets from generated Makefile when `deployment_target` is `none`
- Show `uvx agent-starter-pack enhance` in GEMINI.md command table when no deployment target is configured
- Condense `/invoke` endpoint documentation in GEMINI.md

## Problem
When creating a project with `deployment_target=none`, the Makefile included dummy `deploy` and `backend` targets. This prevented the `enhance` command from properly adding real deployment commands via Makefile merging, since the targets already existed.

## Solution
- Wrapped the deploy section and backend alias in `{%- if cookiecutter.deployment_target != 'none' %}` conditional
- When `deployment_target=none`, the targets are omitted entirely so `enhance` can add them later
- All 57 Makefile template tests pass (hashes and snapshots unchanged for existing configurations)