### PR TITLE
fix: correct import ordering in agentic_rag bq_analytics template

### DIFF
--- a/agent_starter_pack/agents/agentic_rag/app/agent.py
+++ b/agent_starter_pack/agents/agentic_rag/app/agent.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{% if cookiecutter.bq_analytics -%}
+import logging
+{% endif -%}
 import os
 
 import google
@@ -19,15 +22,14 @@ import vertexai
 from google.adk.agents import Agent
 from google.adk.apps import App
 from google.adk.models import Gemini
-from google.genai import types
 {%- if cookiecutter.bq_analytics %}
-import logging
 from google.adk.plugins.bigquery_agent_analytics_plugin import (
     BigQueryAgentAnalyticsPlugin,
     BigQueryLoggerConfig,
 )
 from google.cloud import bigquery
 {%- endif %}
+from google.genai import types
 from langchain_google_vertexai import VertexAIEmbeddings
 
 from {{cookiecutter.agent_directory}}.retrievers import get_compressor, get_retriever


### PR DESCRIPTION
## Summary
- Fixed lint failure when generating `agentic_rag` agent with `--bq-analytics` flag
- `import logging` (stdlib) was incorrectly placed after third-party imports in the Jinja2 template
- BQ plugin imports (`google.adk.plugins`, `google.cloud`) broke isort alphabetical ordering relative to `from google.genai import types`
- The `adk` and `adk_a2a` agents were unaffected because they use `# ruff: noqa`

## Test plan
- [x] `_TEST_AGENT_COMBINATION="agentic_rag,cloud_run,--bq-analytics" make lint-templated-agents` — passes
- [x] `_TEST_AGENT_COMBINATION="agentic_rag,cloud_run" make lint-templated-agents` — passes (regression check, no BQ)
- [x] `_TEST_AGENT_COMBINATION="agentic_rag,agent_engine,--bq-analytics" make lint-templated-agents` — passes
- [x] `_TEST_AGENT_COMBINATION="adk,cloud_run,--bq-analytics" make lint-templated-agents` — passes
- [x] `_TEST_AGENT_COMBINATION="adk_a2a,cloud_run,--bq-analytics" make lint-templated-agents` — passes
- [x] `make test` — 413 passed, 3 skipped
