### PR TITLE
feat: group non-Python agents under Other Languages in selection menu

### DIFF
--- a/agent_starter_pack/agents/adk_go/.template/templateconfig.yaml
+++ b/agent_starter_pack/agents/adk_go/.template/templateconfig.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: "Simple ReAct agent"
+description: "Go agent with A2A"
 example_question: "What's the weather in San Francisco?"
 settings:
   language: "go"

--- a/agent_starter_pack/agents/adk_java/.template/templateconfig.yaml
+++ b/agent_starter_pack/agents/adk_java/.template/templateconfig.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: "Simple ReAct agent"
+description: "Java agent with A2A"
 example_question: "What's the weather in San Francisco?"
 settings:
   language: "java"

--- a/agent_starter_pack/agents/adk_ts/.template/templateconfig.yaml
+++ b/agent_starter_pack/agents/adk_ts/.template/templateconfig.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-description: "Simple ReAct agent"
+description: "TypeScript agent"
 example_question: "What's the weather in San Francisco?"
 settings:
   language: "typescript"

--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -1138,23 +1138,20 @@ def display_agent_selection(
             )
         raise click.ClickException("No valid agents found")
 
-    # Group headers for display
-    GROUP_HEADERS = {
-        "python": "\U0001f40d Python",
-        "go": "\U0001f535 Go",
-        "java": "\u2615\ufe0f Java",
-    }
-
     console.print("\n> Please select an agent to get started:")
 
-    current_group = None
+    current_display_group = None
     for num, agent in agents.items():
-        agent_group = agent["language"]
+        agent_language = agent["language"]
+        display_group = agent_language if agent_language == "python" else "other"
 
         # Print group header when transitioning to a new group
-        if agent_group != current_group:
-            current_group = agent_group
-            header = GROUP_HEADERS.get(agent_group, "\U0001f527 Other")
+        if display_group != current_display_group:
+            current_display_group = display_group
+            if display_group == "python":
+                header = "\U0001f40d Python"
+            else:
+                header = "\U0001f310 Other Languages"
             console.print(f"\n  [bold cyan]{header}[/]")
 
         # Align agent names for cleaner display (use display_name if available)


### PR DESCRIPTION
## Summary
- Collapse Go, Java, and TypeScript agents into a single "🌐 Other Languages" group instead of separate per-language headers
- Update agent descriptions to be language-specific:
  - `adk_go`: "Go agent with A2A"
  - `adk_java`: "Java agent with A2A"
  - `adk_ts`: "TypeScript agent"

## Problem
- Each non-Python language had its own section header with a single agent, creating visual noise
- All three shared the generic "Simple ReAct agent" description, making them hard to differentiate
- The "Other" fallback group used the same 🔧 emoji as "More Options", causing visual confusion

## Solution
- Group all non-Python languages under one "🌐 Other Languages" header
- Give each agent a unique description highlighting its language and capabilities (e.g., A2A support)