### PR TITLE
fix: delete unused datastore terraform files in agentic_rag projects

### DIFF
--- a/agent_starter_pack/base_templates/python/Makefile
+++ b/agent_starter_pack/base_templates/python/Makefile
@@ -351,7 +351,8 @@ sync-data:
 	PROJECT_ID=$$(gcloud config get-value project) && \
 	DATA_STORE_REGION=$$(grep 'data_store_region' deployment/terraform/dev/vars/env.tfvars | sed 's/.*= *"//;s/".*//') && \
 	uv run deployment/terraform/scripts/start_connector_run.py $$PROJECT_ID $$DATA_STORE_REGION {{cookiecutter.project_name}}-collection --wait
-{%- elif cookiecutter.cicd_runner != 'skip' %}
+{%- endif %}
+{%- if cookiecutter.cicd_runner != 'skip' %}
 
 # ==============================================================================
 # Infrastructure Setup

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -123,6 +123,46 @@ CONDITIONAL_FILES = {
     "deployment/terraform/dev/service.tf": _exclude_adk_live_agent_engine,
     # Data ingestion conditional (only for vertex_ai_vector_search)
     "data_ingestion": lambda c: c.get("datastore_type") == "vertex_ai_vector_search",
+    # Datastore-specific terraform files (vertex_ai_search vs vertex_ai_vector_search)
+    "deployment/terraform/vertex_ai_search.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_search"
+    ),
+    "deployment/terraform/vertex_ai_search_variables.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_search"
+    ),
+    "deployment/terraform/vertex_ai_search_github.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_search"
+    ),
+    "deployment/terraform/dev/vertex_ai_search.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_search"
+    ),
+    "deployment/terraform/dev/vertex_ai_search_variables.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_search"
+    ),
+    "deployment/terraform/vector_search.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/vector_search_variables.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/vector_search_github.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/vector_search_iam.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/vector_search_service_accounts.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/dev/vector_search.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/dev/vector_search_variables.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
+    "deployment/terraform/dev/vector_search_iam.tf": (
+        lambda c: c.get("datastore_type") == "vertex_ai_vector_search"
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Delete datastore-specific terraform files that don't match the selected `--datastore` flag
- Fix Makefile template conditional nesting for Infrastructure Setup section

## Problem
Generated `agentic_rag` projects included **both** `vertex_ai_search_*` and `vector_search_*` terraform files regardless of which `--datastore` was selected. The Jinja2 conditionals rendered file contents as empty, but the empty files themselves remained in the project, causing terraform to pick them up and deploy conflicting infrastructure.

Additionally, the Makefile template had the Infrastructure Setup section nested inside an `elif` for `datastore_type == "vertex_ai_search"`, making it unavailable for `vertex_ai_vector_search` projects.

## Changes
- **`agent_starter_pack/cli/utils/template.py`**: Add 13 entries to `CONDITIONAL_FILES` mapping each datastore-specific terraform file (both top-level and `dev/`) to its datastore type condition. Files for the non-selected datastore are deleted during project generation.
- **`agent_starter_pack/base_templates/python/Makefile`**: Split `elif cookiecutter.cicd_runner != 'skip'` into a separate `if` block so the Infrastructure Setup section is independent of the datastore conditional.