### PR TITLE
fix: use europe-west4 region for agentic_rag E2E tests

### DIFF
--- a/tests/cicd/test_e2e_deployment.py
+++ b/tests/cicd/test_e2e_deployment.py
@@ -1196,7 +1196,12 @@ class TestE2EDeployment:
             pytest.skip("Skipping test: Previous test failed in the session")
 
         # Set region based on agent type
-        region = "us-central1" if config.agent == "adk_live" else DEFAULT_REGION
+        if config.agent == "adk_live":
+            region = "us-central1"
+        elif config.agent == "agentic_rag":
+            region = "europe-west4"
+        else:
+            region = DEFAULT_REGION
         github_pat = os.environ.get("GITHUB_PAT")
         github_app_installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID")
 


### PR DESCRIPTION
## Summary
- Route agentic_rag E2E tests to europe-west4 instead of europe-west1

## Problem
E2E builds for agentic_rag with vertex_ai_vector_search fail because the Vector Search Collections beta API (`vectorsearch_v1beta`) returns a 501/404 error in europe-west1, indicating the endpoint is not available in that region.

## Changes
- **`tests/cicd/test_e2e_deployment.py`**: Add `agentic_rag` to region routing logic so it uses `europe-west4` where the API is supported