### PR TITLE
fix: add RAG projects to scheduled cleanup

### DIFF
--- a/.cloudbuild/scheduled-cleanup.yaml
+++ b/.cloudbuild/scheduled-cleanup.yaml
@@ -19,7 +19,7 @@ steps:
     entrypoint: /bin/bash
     env:
       - 'PROJECT_IDS=${_PROJECT_IDS}'
-      - 'E2E_PROJECT_IDS=${_E2E_PROJECT_IDS}'
+      - 'E2E_PROJECT_IDS=${_PROJECT_IDS}'
       - 'CICD_PROJECT_ID=${_CICD_PROJECT_ID}'
     args:
       - "-c"
@@ -34,6 +34,5 @@ options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
 
 substitutions:
-  _PROJECT_IDS: 'asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg'
-  _E2E_PROJECT_IDS: 'asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg'
+  _PROJECT_IDS: 'asp-e2e-dev,asp-e2e-stg,asp-e2e-prd,asp-test-dev,asp-test-prd,asp-test-stg,asp-rag-dev,asp-rag-stg,asp-rag-prd'
   _CICD_PROJECT_ID: 'asp-e2e-cicd'


### PR DESCRIPTION
## Summary
- Add `asp-rag-dev`, `asp-rag-stg`, `asp-rag-prd` to the scheduled cleanup project list
- Unify `_PROJECT_IDS` and `_E2E_PROJECT_IDS` into a single substitution variable

## Problem
RAG project test resources (Agent Engines, Vector Search, Service Accounts, etc.) were not being cleaned up by the daily scheduled job because the RAG projects were missing from the cleanup config.

## Changes
- **`.cloudbuild/scheduled-cleanup.yaml`**: Add RAG projects to `_PROJECT_IDS`, remove redundant `_E2E_PROJECT_IDS` substitution (both env vars now fed from `_PROJECT_IDS`)