### PR TITLE
chore: update makefile snapshots and hashes for agentic_rag

### DIFF
--- a/tests/fixtures/makefile_hashes.json
+++ b/tests/fixtures/makefile_hashes.json
@@ -9,8 +9,8 @@
   "adk_live_cloud_run": "698b4d427a75ee68c05a088ff52a3527cfb3a6cf7e27249d41f8d8f29b8031ce",
   "agent_with_agent_garden": "f0b80a4f0ba01f7707f9092b0be34f4f849db304743273c963f3a7f18f574ebe",
   "agent_with_custom_commands": "94ef1dad6062e1bf793aec54b59147cb41e93e26629b0fa073df44253fa46a14",
-  "agentic_rag_cloud_run_vector_search": "ea571809c4968a9616798c9fc5dea25e47e2510b3946c952fa58fab8d4e98ed0",
-  "agentic_rag_cloud_run_vertex_search": "b61e4141ebdfebf5fb8fc3e4a1b7a3857bfe4eeba725554c50336dbbbed10287",
+  "agentic_rag_cloud_run_vector_search": "976e1041a2a77298ab9e90356de3a758ba10fbd4013ceb7441607d4b7b5adda3",
+  "agentic_rag_cloud_run_vertex_search": "e931cb69116f79dfd8c552da1ff6041c50ec44972684318baaeda96c8e82e92e",
   "langgraph_agent_engine": "a33a5b0a881b8c4d103f6aa01081a0bd00160a5ef3765d17a8a1b1b812c2d9b8",
   "langgraph_cloud_run": "12a25058259f90c4f58748c700c599860b5a2c1d69b249ab8105ada288790d50"
 }

--- a/tests/fixtures/makefile_snapshots/agentic_rag_cloud_run_vector_search.makefile
+++ b/tests/fixtures/makefile_snapshots/agentic_rag_cloud_run_vector_search.makefile
@@ -78,6 +78,15 @@ data-ingestion:
 		--local)
 
 # ==============================================================================
+# Infrastructure Setup
+# ==============================================================================
+
+# Set up development environment resources using Terraform
+setup-dev-env:
+	PROJECT_ID=$$(gcloud config get-value project) && \
+	(cd deployment/terraform/dev && terraform init && terraform apply --var-file vars/env.tfvars --var dev_project_id=$$PROJECT_ID --auto-approve)
+
+# ==============================================================================
 # Testing & Code Quality
 # ==============================================================================
 

--- a/tests/fixtures/makefile_snapshots/agentic_rag_cloud_run_vertex_search.makefile
+++ b/tests/fixtures/makefile_snapshots/agentic_rag_cloud_run_vertex_search.makefile
@@ -80,6 +80,15 @@ sync-data:
 	uv run deployment/terraform/scripts/start_connector_run.py $$PROJECT_ID $$DATA_STORE_REGION test-rag-collection --wait
 
 # ==============================================================================
+# Infrastructure Setup
+# ==============================================================================
+
+# Set up development environment resources using Terraform
+setup-dev-env:
+	PROJECT_ID=$$(gcloud config get-value project) && \
+	(cd deployment/terraform/dev && terraform init && terraform apply --var-file vars/env.tfvars --var dev_project_id=$$PROJECT_ID --auto-approve)
+
+# ==============================================================================
 # Testing & Code Quality
 # ==============================================================================
 


### PR DESCRIPTION
## Summary
- Regenerate makefile snapshots and hashes after the Makefile template change that added the Infrastructure Setup section for agentic_rag variants