### PR TITLE
fix: use gemini-3-flash-preview as eval judge model

### DIFF
--- a/agent_starter_pack/agents/adk/tests/eval/eval_config.json
+++ b/agent_starter_pack/agents/adk/tests/eval/eval_config.json
@@ -2,6 +2,10 @@
   "criteria": {
     "rubric_based_final_response_quality_v1": {
       "threshold": 0.8,
+      "judgeModelOptions": {
+        "judgeModel": "gemini-3-flash-preview",
+        "numSamples": 1
+      },
       "rubrics": [
         {
           "rubricId": "relevance",

--- a/agent_starter_pack/agents/adk_a2a/tests/eval/eval_config.json
+++ b/agent_starter_pack/agents/adk_a2a/tests/eval/eval_config.json
@@ -2,6 +2,10 @@
   "criteria": {
     "rubric_based_final_response_quality_v1": {
       "threshold": 0.8,
+      "judgeModelOptions": {
+        "judgeModel": "gemini-3-flash-preview",
+        "numSamples": 1
+      },
       "rubrics": [
         {
           "rubricId": "relevance",

--- a/agent_starter_pack/agents/agentic_rag/tests/eval/eval_config.json
+++ b/agent_starter_pack/agents/agentic_rag/tests/eval/eval_config.json
@@ -2,6 +2,10 @@
   "criteria": {
     "rubric_based_final_response_quality_v1": {
       "threshold": 0.8,
+      "judgeModelOptions": {
+        "judgeModel": "gemini-3-flash-preview",
+        "numSamples": 1
+      },
       "rubrics": [
         {
           "rubricId": "relevance",


### PR DESCRIPTION
## Summary
- Override default eval judge model from `gemini-2.5-flash` to `gemini-3-flash-preview` in all agent template eval configs
- Set `numSamples` to 1 (down from default 5) for faster evaluation during development

## Changes
- `agent_starter_pack/agents/adk/tests/eval/eval_config.json`
- `agent_starter_pack/agents/adk_a2a/tests/eval/eval_config.json`
- `agent_starter_pack/agents/agentic_rag/tests/eval/eval_config.json`

## Context
ADK evaluation defaults to `gemini-2.5-flash` with 5 samples per invocation (defined in `google.adk.evaluation.eval_metrics.JudgeModelOptions`). This adds `judgeModelOptions` to explicitly set the judge to `gemini-3-flash-preview` with 1 sample, reducing eval latency and cost.