### PR TITLE
fix: improve enhance command with bug fixes and UX improvements

### DIFF
--- a/agent_starter_pack/agents/adk_ts/.template/templateconfig.yaml
+++ b/agent_starter_pack/agents/adk_ts/.template/templateconfig.yaml
@@ -18,7 +18,7 @@ settings:
   language: "typescript"
   requires_data_ingestion: false
   requires_session: false
-  deployment_targets: ["cloud_run"]
+  deployment_targets: ["cloud_run", "none"]
   extra_dependencies: []
   tags: ["adk", "typescript"]
   frontend_type: "None"

--- a/agent_starter_pack/cli/utils/generation_metadata.py
+++ b/agent_starter_pack/cli/utils/generation_metadata.py
@@ -40,7 +40,7 @@ def metadata_to_cli_args(metadata: dict[str, Any]) -> list[str]:
         if (
             value is None
             or value is False
-            or str(value).lower() == "none"
+            or str(value).lower() in ("none", "skip")
             or value == ""
         ):
             continue

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -674,7 +674,9 @@ def get_deployment_targets(
 
 
 def prompt_deployment_target(
-    agent_name: str, remote_config: dict[str, Any] | None = None
+    agent_name: str,
+    remote_config: dict[str, Any] | None = None,
+    default_value: str | None = None,
 ) -> str:
     """Ask user to select a deployment target for the agent."""
     targets = get_deployment_targets(agent_name, remote_config=remote_config)
@@ -698,6 +700,10 @@ def prompt_deployment_target(
     if not targets:
         return ""
 
+    default_idx = 1
+    if default_value and default_value in targets:
+        default_idx = targets.index(default_value) + 1
+
     console = Console()
     console.print("\n> Please select a deployment target:")
     console.print("\n  [bold cyan]☁️  Deployment Targets[/]")
@@ -705,18 +711,27 @@ def prompt_deployment_target(
         info = TARGET_INFO.get(target, {})
         display_name = info.get("display_name", target)
         description = info.get("description", "")
-        name_padded = display_name.ljust(14)
-        console.print(f"     {idx}. [bold]{name_padded}[/] [dim]{description}[/]")
+        if target == default_value:
+            name_padded = display_name.ljust(14)
+            console.print(
+                f"     {idx}. [bold cyan]{name_padded}[/] [dim]{description}[/]"
+                "  [dim cyan](current)[/]"
+            )
+        elif default_value:
+            console.print(f"     [dim]{idx}. {display_name.ljust(14)} {description}[/]")
+        else:
+            name_padded = display_name.ljust(14)
+            console.print(f"     {idx}. [bold]{name_padded}[/] [dim]{description}[/]")
 
     choice = IntPrompt.ask(
         "\nEnter the number of your deployment target choice",
-        default=1,
+        default=default_idx,
         show_default=True,
     )
     return targets[choice - 1]
 
 
-def prompt_session_type_selection() -> str:
+def prompt_session_type_selection(default_value: str | None = None) -> str:
     """Ask user to select a session type for Cloud Run deployment."""
     console = Console()
 
@@ -735,21 +750,35 @@ def prompt_session_type_selection() -> str:
         },
     }
 
+    default_idx = 1
+    keys = list(session_types.keys())
+    if default_value and default_value in keys:
+        default_idx = keys.index(default_value) + 1
+
     console.print("\n> Please select a session type:")
     console.print("\n  [bold cyan]💾 Session Types[/]")
-    for idx, (_key, info) in enumerate(session_types.items(), 1):
-        name_padded = info["display_name"].ljust(14)
-        console.print(
-            f"     {idx}. [bold]{name_padded}[/] [dim]{info['description']}[/]"
-        )
+    for idx, (key, info) in enumerate(session_types.items(), 1):
+        display_name = info["display_name"]
+        description = info["description"]
+        if key == default_value:
+            name_padded = display_name.ljust(14)
+            console.print(
+                f"     {idx}. [bold cyan]{name_padded}[/] [dim]{description}[/]"
+                "  [dim cyan](current)[/]"
+            )
+        elif default_value:
+            console.print(f"     [dim]{idx}. {display_name.ljust(14)} {description}[/]")
+        else:
+            name_padded = display_name.ljust(14)
+            console.print(f"     {idx}. [bold]{name_padded}[/] [dim]{description}[/]")
 
     choice = IntPrompt.ask(
         "\nEnter the number of your session type choice",
-        default=1,
+        default=default_idx,
         show_default=True,
     )
 
-    return list(session_types.keys())[choice - 1]
+    return keys[choice - 1]
 
 
 def _display_datastore_menu(console: Console) -> str:
@@ -816,7 +845,7 @@ def prompt_datastore_selection(
     return _display_datastore_menu(console)
 
 
-def prompt_cicd_runner_selection() -> str:
+def prompt_cicd_runner_selection(default_value: str | None = None) -> str:
     """Ask user to select a CI/CD runner."""
     console = Console()
 
@@ -835,21 +864,27 @@ def prompt_cicd_runner_selection() -> str:
         },
     }
 
+    default_idx = 1
+    keys = list(cicd_runners.keys())
+    if default_value and default_value in keys:
+        default_idx = keys.index(default_value) + 1
+
     console.print("\n> Please select a CI/CD runner:")
     console.print("\n  [bold cyan]🔧 CI/CD Options[/]")
-    for idx, (_key, info) in enumerate(cicd_runners.items(), 1):
+    for idx, (key, info) in enumerate(cicd_runners.items(), 1):
         name_padded = info["display_name"].ljust(20)
+        current = "  [dim](current)[/]" if key == default_value else ""
         console.print(
-            f"     {idx}. [bold]{name_padded}[/] [dim]{info['description']}[/]"
+            f"     {idx}. [bold]{name_padded}[/] [dim]{info['description']}[/]{current}"
         )
 
     choice = IntPrompt.ask(
         "\nEnter the number of your CI/CD runner choice",
-        default=1,
+        default=default_idx,
         show_default=True,
     )
 
-    return list(cicd_runners.keys())[choice - 1]
+    return keys[choice - 1]
 
 
 def get_template_path(agent_name: str, debug: bool = False) -> pathlib.Path:


### PR DESCRIPTION
## Summary
- Fix multiple bugs in the `enhance` command's 3-way comparison, dependency handling, and interactive flow
- Align enhance UX with the `create` command's rich numbered menus
- Add multi-language support for metadata updates and agent code detection

## Bug Fixes
- **User-added files incorrectly shown as "Preserving"**: Files only in the current project (not in either template) had `None == None` pass the hash check, returning "preserve" instead of "skip"
- **Dependency extras treated as different packages**: `google-cloud-aiplatform[evaluation]` and `google-cloud-aiplatform[evaluation,agent-engines]` were treated as separate packages, causing duplicate add/remove entries
- **`metadata_to_cli_args` not filtering "skip"**: `cicd_runner = "skip"` was passed as `--cicd-runner skip` to template regeneration, causing hash mismatches
- **Enhance not showing file changes**: When running without CLI overrides or via subprocess, enhance skipped the comparison display and confirmation flow entirely
- **`--base-template` override not working**: `_build_enhance_create_args` mapped `base_template` to `--base-template` (remote templates) instead of `--agent` (local agent selection)
- **Corrupted pyproject.toml from regex**: Replaced regex-based dependency writing with `uv add --frozen` / `uv remove --frozen`

## UX Improvements
- Use the same rich numbered menus as `create` for deployment target, session type, and CI/CD runner selection
- Add agent/base_template selection to the enhance customize flow
- Show `(current)` marker in cyan on active selections, dim non-current choices
- Add bulk conflict resolution: `(K)eep all` and `(U)se all` options
- Use prospective language in preview: "Files to add" / "Files to remove" instead of past tense
- Remove redundant per-file prompts after global "Proceed with enhancement?" confirmation
- Filter customize options based on agent template capabilities (e.g., Go agents don't show session_type)

## Multi-language Support
- Add TypeScript patterns (`*.ts`) to agent code file categories
- Add `package.json` / `package-lock.json` to dependency file categories
- Support metadata updates across all languages (pyproject.toml, .asp.toml, pom.xml)
- Remove stale metadata keys (e.g., `session_type`) when switching deployment targets
- Add `none` deployment target to `adk_ts` template config

## Files Changed
- `agent_starter_pack/cli/commands/enhance.py` — Smart-merge flow, customize prompts, metadata updates
- `agent_starter_pack/cli/utils/upgrade.py` — 3-way compare, dependency parsing, metadata removal
- `agent_starter_pack/cli/utils/merge.py` — Display labels, conflict resolution, Rich markup escaping
- `agent_starter_pack/cli/utils/template.py` — `default_value` param and `(current)` markers on prompts
- `agent_starter_pack/cli/utils/generation_metadata.py` — Filter "skip" values
- `agent_starter_pack/agents/adk_ts/.template/templateconfig.yaml` — Add `none` target
- `tests/` — 122 tests passing, covering all new behavior