### PR TITLE
fix: allow clearing secrets from deployed Agent Engine

### DIFF
--- a/agent_starter_pack/base_templates/python/Makefile
+++ b/agent_starter_pack/base_templates/python/Makefile
@@ -266,7 +266,7 @@ build-inspector-if-needed:
 {%- if cookiecutter.deployment_target == 'cloud_run' %}
 # Usage: make deploy [IAP=true] [PORT=8080] - Set IAP=true to enable Identity-Aware Proxy, PORT to specify container port
 {%- elif cookiecutter.deployment_target == 'agent_engine' %}
-# Usage: make deploy [AGENT_IDENTITY=true] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
+# Usage: make deploy [AGENT_IDENTITY=true] [SECRETS="KEY=SECRET_ID,..."] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
 {%- endif %}
 deploy:
 {%- if cookiecutter.deployment_target == 'cloud_run' %}
@@ -296,7 +296,8 @@ deploy:
 		--entrypoint-module={{cookiecutter.agent_directory}}.agent_engine_app \
 		--entrypoint-object=agent_engine \
 		--requirements-file={{cookiecutter.agent_directory}}/app_utils/.requirements.txt \
-		$(if $(AGENT_IDENTITY),--agent-identity)
+		$(if $(AGENT_IDENTITY),--agent-identity) \
+		$(if $(filter command line,$(origin SECRETS)),--set-secrets="$(SECRETS)")
 {%- endif %}
 
 # Alias for 'make deploy' for backward compatibility

--- a/agent_starter_pack/resources/docs/adk-deploy-guide.md
+++ b/agent_starter_pack/resources/docs/adk-deploy-guide.md
@@ -170,12 +170,17 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 
 **Agent Engine:**
 
-Pass secrets during deployment with `--set-secrets`. Note: `make deploy` doesn't support secrets, so run deploy.py directly:
+Pass secrets during deployment with the `SECRETS` variable:
 ```bash
-uv run python -m <your-agent-directory>.app_utils.deploy --set-secrets "API_KEY=my-api-key,DB_PASS=db-password:2"
+make deploy SECRETS="API_KEY=my-api-key,DB_PASS=db-password:2"
 ```
 
 Format: `ENV_VAR=SECRET_ID` or `ENV_VAR=SECRET_ID:VERSION` (defaults to latest).
+
+To remove all secrets from a deployed agent:
+```bash
+make deploy SECRETS=""
+```
 
 In your agent code, access via `os.environ`:
 ```python

--- a/tests/fixtures/makefile_hashes.json
+++ b/tests/fixtures/makefile_hashes.json
@@ -1,16 +1,16 @@
 {
-  "adk_a2a_agent_engine": "b4d2e22711f96d8ec3e4fa7c424baf6172b5c6ecd99f90304d545a34ebf47b89",
+  "adk_a2a_agent_engine": "b2ca32d41f6ecd7277e88ec39fe44047c16e39dd8db812b8b31792db8a528ccb",
   "adk_a2a_cloud_run": "0c4b6a003fea4aa00af93aace24d3580d876afb4c1d88732b81f0feabc1d3614",
-  "adk_agent_engine_no_data": "11b4683f3a7a9aef3fe36bee576825299a44887dc159b6cb93e6284d46a0cbc6",
+  "adk_agent_engine_no_data": "92e6c73160d77026ec34c64a95d7c17d64ebb42bec9baee4af77e62b013e6c9b",
   "adk_cloud_run_no_data": "dff3a0b8e1f1c51961d4ba2ac666ce02f45658a89ef2fc45517164977c528e19",
   "adk_go_cloud_run": "2e38a95aae0deea7849ebf7b71580b3690b53e79f3377ad87cc2d0fd1dde425a",
   "adk_java_cloud_run": "91134e43285a425ea50b47cc4f8a6052ed17104a1f98d1965c6050936deace2b",
-  "adk_live_agent_engine": "03ddbdd3af3189f1a88bf9dc33be3d440cedcdc85e47203bba808051dac602f8",
+  "adk_live_agent_engine": "30a4b5ac3cb723547f128f3a25171b9cc2564845fdd8e9202b631abea46594c5",
   "adk_live_cloud_run": "698b4d427a75ee68c05a088ff52a3527cfb3a6cf7e27249d41f8d8f29b8031ce",
   "agent_with_agent_garden": "f0b80a4f0ba01f7707f9092b0be34f4f849db304743273c963f3a7f18f574ebe",
   "agent_with_custom_commands": "94ef1dad6062e1bf793aec54b59147cb41e93e26629b0fa073df44253fa46a14",
   "agentic_rag_cloud_run_vector_search": "976e1041a2a77298ab9e90356de3a758ba10fbd4013ceb7441607d4b7b5adda3",
   "agentic_rag_cloud_run_vertex_search": "e931cb69116f79dfd8c552da1ff6041c50ec44972684318baaeda96c8e82e92e",
-  "langgraph_agent_engine": "a33a5b0a881b8c4d103f6aa01081a0bd00160a5ef3765d17a8a1b1b812c2d9b8",
+  "langgraph_agent_engine": "056eb35542df600cb145003514c4b52f6af0a24df6b370025b898462869f567c",
   "langgraph_cloud_run": "12a25058259f90c4f58748c700c599860b5a2c1d69b249ab8105ada288790d50"
 }

--- a/tests/fixtures/makefile_snapshots/adk_a2a_agent_engine.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_a2a_agent_engine.makefile
@@ -78,7 +78,7 @@ build-inspector-if-needed:
 # ==============================================================================
 
 # Deploy the agent remotely
-# Usage: make deploy [AGENT_IDENTITY=true] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
+# Usage: make deploy [AGENT_IDENTITY=true] [SECRETS="KEY=SECRET_ID,..."] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
 deploy:
 	# Export dependencies to requirements file using uv export.
 	(uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > test_a2a/app_utils/.requirements.txt 2>/dev/null || \
@@ -88,7 +88,8 @@ deploy:
 		--entrypoint-module=test_a2a.agent_engine_app \
 		--entrypoint-object=agent_engine \
 		--requirements-file=test_a2a/app_utils/.requirements.txt \
-		$(if $(AGENT_IDENTITY),--agent-identity)
+		$(if $(AGENT_IDENTITY),--agent-identity) \
+		$(if $(filter command line,$(origin SECRETS)),--set-secrets="$(SECRETS)")
 
 # Alias for 'make deploy' for backward compatibility
 backend: deploy

--- a/tests/fixtures/makefile_snapshots/adk_agent_engine_no_data.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_agent_engine_no_data.makefile
@@ -28,7 +28,7 @@ playground:
 # ==============================================================================
 
 # Deploy the agent remotely
-# Usage: make deploy [AGENT_IDENTITY=true] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
+# Usage: make deploy [AGENT_IDENTITY=true] [SECRETS="KEY=SECRET_ID,..."] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
 deploy:
 	# Export dependencies to requirements file using uv export.
 	(uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > test_adk/app_utils/.requirements.txt 2>/dev/null || \
@@ -38,7 +38,8 @@ deploy:
 		--entrypoint-module=test_adk.agent_engine_app \
 		--entrypoint-object=agent_engine \
 		--requirements-file=test_adk/app_utils/.requirements.txt \
-		$(if $(AGENT_IDENTITY),--agent-identity)
+		$(if $(AGENT_IDENTITY),--agent-identity) \
+		$(if $(filter command line,$(origin SECRETS)),--set-secrets="$(SECRETS)")
 
 # Alias for 'make deploy' for backward compatibility
 backend: deploy

--- a/tests/fixtures/makefile_snapshots/adk_live_agent_engine.makefile
+++ b/tests/fixtures/makefile_snapshots/adk_live_agent_engine.makefile
@@ -86,7 +86,7 @@ playground-dev:
 # ==============================================================================
 
 # Deploy the agent remotely
-# Usage: make deploy [AGENT_IDENTITY=true] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
+# Usage: make deploy [AGENT_IDENTITY=true] [SECRETS="KEY=SECRET_ID,..."] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
 deploy:
 	# Export dependencies to requirements file using uv export.
 	(uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > test_adk_live/app_utils/.requirements.txt 2>/dev/null || \
@@ -96,7 +96,8 @@ deploy:
 		--entrypoint-module=test_adk_live.agent_engine_app \
 		--entrypoint-object=agent_engine \
 		--requirements-file=test_adk_live/app_utils/.requirements.txt \
-		$(if $(AGENT_IDENTITY),--agent-identity)
+		$(if $(AGENT_IDENTITY),--agent-identity) \
+		$(if $(filter command line,$(origin SECRETS)),--set-secrets="$(SECRETS)")
 
 # Alias for 'make deploy' for backward compatibility
 backend: deploy

--- a/tests/fixtures/makefile_snapshots/langgraph_agent_engine.makefile
+++ b/tests/fixtures/makefile_snapshots/langgraph_agent_engine.makefile
@@ -77,7 +77,7 @@ build-inspector-if-needed:
 # ==============================================================================
 
 # Deploy the agent remotely
-# Usage: make deploy [AGENT_IDENTITY=true] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
+# Usage: make deploy [AGENT_IDENTITY=true] [SECRETS="KEY=SECRET_ID,..."] - Set AGENT_IDENTITY=true to enable per-agent IAM identity (Preview)
 deploy:
 	# Export dependencies to requirements file using uv export.
 	(uv export --no-hashes --no-header --no-dev --no-emit-project --no-annotate > test_langgraph/app_utils/.requirements.txt 2>/dev/null || \
@@ -87,7 +87,8 @@ deploy:
 		--entrypoint-module=test_langgraph.agent_engine_app \
 		--entrypoint-object=agent_engine \
 		--requirements-file=test_langgraph/app_utils/.requirements.txt \
-		$(if $(AGENT_IDENTITY),--agent-identity)
+		$(if $(AGENT_IDENTITY),--agent-identity) \
+		$(if $(filter command line,$(origin SECRETS)),--set-secrets="$(SECRETS)")
 
 # Alias for 'make deploy' for backward compatibility
 backend: deploy


### PR DESCRIPTION
Fixes #735 — updating an Agent Engine with `--set-secrets=""` now correctly removes all secrets from the deployed resource.