### PR TITLE
feat: broaden E2E test coverage on release commits

### DIFF
--- a/.cloudbuild/terraform/build_triggers.tf
+++ b/.cloudbuild/terraform/build_triggers.tf
@@ -348,6 +348,19 @@ locals {
   # All other combos only watch agent-specific + deployment-target-specific paths.
   e2e_sentinel_combos = toset(["adk-agent_engine", "adk-cloud_run", "adk-gke"])
 
+  # Release combos additionally watch pyproject.toml/uv.lock so they trigger
+  # on version bumps and dependency changes (e.g. release commits).
+  # Covers key agent types and all languages for broader release validation.
+  e2e_release_combos = toset([
+    "langgraph-agent_engine",
+    "agentic_rag-agent_engine-vertex_ai_search",
+    "adk_live-cloud_run",
+    "adk_a2a-cloud_run",
+    "adk_go-cloud_run",
+    "adk_java-cloud_run",
+    "adk_ts-cloud_run",
+  ])
+
   # Go-specific E2E included files - auto-derives deployment target from combo value
   go_e2e_agent_deployment_included_files = {
     for combo in local.e2e_agent_deployment_combinations :
@@ -393,7 +406,7 @@ locals {
   }
 
   e2e_agent_deployment_included_files = { for combo in local.e2e_agent_deployment_combinations :
-    combo.name => (
+    combo.name => concat(
       endswith(split(",", combo.value)[0], "_go") ? local.go_e2e_agent_deployment_included_files[combo.name] :
       endswith(split(",", combo.value)[0], "_java") ? local.java_e2e_agent_deployment_included_files[combo.name] :
       endswith(split(",", combo.value)[0], "_ts") ? local.ts_e2e_agent_deployment_included_files[combo.name] :
@@ -430,7 +443,9 @@ locals {
         "agent_starter_pack/agents/${split(",", combo.value)[0]}/**",
         "agent_starter_pack/deployment_targets/${split(",", combo.value)[1]}/_shared/**",
         "agent_starter_pack/deployment_targets/${split(",", combo.value)[1]}/python/**",
-      ]
+      ],
+      # Release combos additionally watch pyproject.toml/uv.lock
+      contains(local.e2e_release_combos, combo.name) ? ["pyproject.toml", "uv.lock"] : []
     )
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-starter-pack"
-version = "0.39.0"
+version = "0.38.0"
 description = "CLI to bootstrap production-ready Google Cloud GenAI agent projects from templates."
 authors = [
     { name = "Google LLC", email = "agent-starter-pack@google.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-starter-pack"
-version = "0.39.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
## Summary
- Add `e2e_release_combos` set for E2E triggers that additionally fire on `pyproject.toml`/`uv.lock` changes
- Use `concat` to append release files to narrow paths for release combos
- Sentinel combos unchanged (3 combos with broad paths)
- Revert pyproject.toml version to 0.38.0

## Problem
Release commits (version bumps) only change `pyproject.toml` and `uv.lock`, which meant only the 3 sentinel E2E combos (`adk` × 3 deployment targets) would trigger. This left most agent types and all non-Python languages untested during releases.

## Solution
Introduced `e2e_release_combos` — 7 additional combos that additionally watch `pyproject.toml`/`uv.lock`. On release commits, 10 E2E tests now fire (3 sentinels + 7 release combos) covering:
- All deployment targets (agent_engine, cloud_run, gke)
- All languages (Python, Go, Java, TypeScript)
- Key agent types (adk, langgraph, agentic_rag, adk_live, adk_a2a)

Regular commits are unaffected — release combos still only fire on their narrow agent/deployment paths for non-release changes. Terraform already applied.