### PR TITLE
fix: remove telemetry_outputs.tf alongside telemetry.tf in E2E tests

### DIFF
--- a/tests/cicd/test_e2e_deployment.py
+++ b/tests/cicd/test_e2e_deployment.py
@@ -1193,7 +1193,9 @@ class TestE2EDeployment:
 
         telemetry_files = [
             project_dir / "deployment" / "terraform" / "telemetry.tf",
+            project_dir / "deployment" / "terraform" / "telemetry_outputs.tf",
             project_dir / "deployment" / "terraform" / "dev" / "telemetry.tf",
+            project_dir / "deployment" / "terraform" / "dev" / "telemetry_outputs.tf",
         ]
 
         for tf_file in telemetry_files:


### PR DESCRIPTION
## Summary
- Include `telemetry_outputs.tf` in the E2E quota-saving telemetry removal logic

## Problem
E2E tests fail with Terraform "Reference to undeclared resource" errors:
- `google_bigquery_dataset.telemetry_dataset` not declared
- `google_bigquery_connection.genai_telemetry_connection` not declared

The `remove_telemetry_for_quota_savings` method removes `telemetry.tf` (which defines the BigQuery resources) but leaves `telemetry_outputs.tf` (which references them), causing Terraform to fail.

## Solution
Added `telemetry_outputs.tf` to the list of files removed in both `deployment/terraform/` and `deployment/terraform/dev/` directories.