### PR TITLE
feat: add AG2 multi-agent template with A2A protocol support

### DIFF
--- a/agent_starter_pack/agents/ag2/.template/templateconfig.yaml
+++ b/agent_starter_pack/agents/ag2/.template/templateconfig.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+display_name: "ag2"
+description: "Multi-agent collaboration with AG2 and A2A protocol"
+settings:
+  requires_data_ingestion: false
+  requires_session: false
+  deployment_targets: ["cloud_run", "gke", "none"]
+  extra_dependencies:
+    - "ag2[gemini]>=0.11.0,<1.0.0"
+    - "a2a-sdk[http-server]~=0.3.22"
+    - "nest-asyncio>=1.6.0,<2.0.0"
+    - "traceloop-sdk>=0.10.0,<1.0.0"
+    - "opentelemetry-exporter-gcp-trace>=1.9.0,<2.0.0"
+    - "python-dotenv>=1.0.0,<2.0.0"
+  tags: ["ag2", "a2a"]
+  frontend_type: "inspector"
+example_question: "Design and implement a REST API for a wiki service with article CRUD operations and search"

--- a/agent_starter_pack/agents/ag2/README.md
+++ b/agent_starter_pack/agents/ag2/README.md
@@ -1,0 +1,50 @@
+# AG2 Multi-Agent with A2A Protocol
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/ag2ai/ag2/refs/heads/main/website/static/img/ag2.svg" width="50%" alt="AG2 Logo" style="margin-right: 40px; vertical-align: middle;">
+  <img src="https://github.com/a2aproject/A2A/blob/main/docs/assets/a2a-logo-white.svg?raw=true" width="40%" alt="A2A Logo" style="vertical-align: middle;">
+</p>
+
+A multi-agent system built using **[AG2](https://ag2.ai/)** with **[Agent2Agent (A2A) Protocol](https://a2a-protocol.org/)** support. This template demonstrates how to build a collaborative multi-agent pipeline where specialized agents hand off work to each other using AG2's handoff routing.
+
+## Architecture
+
+The template implements a three-agent pipeline:
+
+1. **Architect** - Designs system architecture given a user request
+2. **Coder** - Implements the system based on the architect's design
+3. **Reviewer** - Reviews the code and either approves or requests changes
+
+Agents communicate through AG2's handoff mechanism using `OnCondition` with `StringLLMCondition` for intelligent routing.
+
+## Key Features
+
+- **Multi-Agent Collaboration**: Three specialized agents working together via handoffs
+- **A2A Protocol Support**: Each agent is exposed as an individual A2A endpoint
+- **Streaming Support**: Real-time response streaming
+- **AG2 Native**: Uses AG2's `DefaultPattern` for orchestration and built-in session management
+
+## Validating Your A2A Implementation
+
+This template includes the **[A2A Protocol Inspector](https://github.com/a2aproject/a2a-inspector)** for validating your agent's A2A implementation.
+
+```bash
+make inspector
+```
+
+Each agent is mounted at its own A2A endpoint:
+- Architect: `http://localhost:8000/a2a/architect/`
+- Coder: `http://localhost:8000/a2a/coder/`
+- Reviewer: `http://localhost:8000/a2a/reviewer/`
+
+## Running the Full Pipeline
+
+To trigger the full architect -> coder -> reviewer pipeline, use the `/run` endpoint:
+
+```bash
+curl -X POST http://localhost:8000/run \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Design and implement a REST API for a wiki service with article CRUD operations and search"}'
+```
+
+The pipeline runs with `max_rounds=20` by default (configurable via the `max_rounds` field).

--- a/agent_starter_pack/agents/ag2/app/__init__.py
+++ b/agent_starter_pack/agents/ag2/app/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .agent import architect, coder, pattern, reviewer, root_agent
+
+__all__ = ["root_agent", "architect", "coder", "reviewer", "pattern"]

--- a/agent_starter_pack/agents/ag2/app/agent.py
+++ b/agent_starter_pack/agents/ag2/app/agent.py
@@ -1,0 +1,131 @@
+# ruff: noqa
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from autogen import ConversableAgent, LLMConfig
+from autogen.agentchat.group import (
+    AgentTarget,
+    ContextVariables,
+    OnCondition,
+    RevertToUserTarget,
+    StringLLMCondition,
+)
+from autogen.agentchat.group.patterns import DefaultPattern
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MODEL = "gemini-2.5-flash"
+{%- if not cookiecutter.use_google_api_key %}
+
+import google.auth
+
+_, project_id = google.auth.default()
+os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+{%- endif %}
+
+llm_config = LLMConfig({"api_type": "google", "model": MODEL})
+
+# --- Agent Definitions ---
+
+architect = ConversableAgent(
+    name="architect",
+    system_message=(
+        "You are a distributed systems architect. "
+        "Given a user request, design the system architecture including: "
+        "core components and responsibilities, data storage strategy, "
+        "API layer and service interfaces, and deployment topology. "
+        "Output a clear, actionable design document for the coder."
+    ),
+    llm_config=llm_config,
+    human_input_mode="NEVER",
+)
+
+coder = ConversableAgent(
+    name="coder",
+    system_message=(
+        "You are a senior backend engineer. "
+        "Implement the system based on the architect's design. "
+        "Write production-quality Python code with clean interfaces, "
+        "type hints, and proper error handling."
+    ),
+    llm_config=llm_config,
+    human_input_mode="NEVER",
+)
+
+reviewer = ConversableAgent(
+    name="reviewer",
+    system_message=(
+        "You are a principal engineer conducting code review. "
+        "Review the implementation for correctness, scalability, "
+        "and adherence to the design. "
+        "Either APPROVE with a summary, or REQUEST CHANGES with specifics."
+    ),
+    llm_config=llm_config,
+    human_input_mode="NEVER",
+)
+
+# --- Handoff Routing ---
+
+architect.handoffs.add_llm_conditions([
+    OnCondition(
+        target=AgentTarget(coder),
+        condition=StringLLMCondition(
+            prompt="Route to coder when the design is complete and ready to implement."
+        ),
+    ),
+])
+
+coder.handoffs.add_llm_conditions([
+    OnCondition(
+        target=AgentTarget(reviewer),
+        condition=StringLLMCondition(
+            prompt="Route to reviewer when the implementation is complete."
+        ),
+    ),
+])
+
+reviewer.handoffs.add_llm_conditions([
+    OnCondition(
+        target=AgentTarget(coder),
+        condition=StringLLMCondition(
+            prompt="Route back to coder when changes are requested."
+        ),
+    ),
+])
+reviewer.handoffs.set_after_work(RevertToUserTarget())
+
+# --- Orchestration ---
+
+user = ConversableAgent(name="user", human_input_mode="NEVER")
+
+context_variables = ContextVariables(data={"phase": "design"})
+
+pattern = DefaultPattern(
+    initial_agent=architect,
+    agents=[architect, coder, reviewer],
+    user_agent=user,
+    context_variables=context_variables,
+    group_after_work=RevertToUserTarget(),
+)
+
+# Entry point for A2A server
+root_agent = architect
+
+# Prevent ADK app injection - AG2 uses its own A2A server
+app = None

--- a/agent_starter_pack/agents/ag2/app/app_utils/telemetry.py
+++ b/agent_starter_pack/agents/ag2/app/app_utils/telemetry.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry setup for AG2 agents on Google Cloud."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def setup_telemetry() -> str | None:
+    """Configure OpenTelemetry tracing for AG2 agents.
+
+    Sets up Cloud Trace export when running on Cloud Run or GKE.
+    Locally, tracing is disabled by default to avoid requiring credentials.
+    """
+    bucket = os.environ.get("LOGS_BUCKET_NAME")
+
+    if not os.getenv("K_SERVICE"):
+        return bucket
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(CloudTraceSpanExporter()))
+        trace.set_tracer_provider(provider)
+    except ImportError:
+        logger.debug("OpenTelemetry Cloud Trace dependencies not installed, skipping")
+
+    return bucket

--- a/agent_starter_pack/agents/ag2/notebooks/evaluating_ag2_agent.ipynb
+++ b/agent_starter_pack/agents/ag2/notebooks/evaluating_ag2_agent.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2026 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluating AG2 Multi-Agent Pipeline\n",
+    "\n",
+    "This notebook demonstrates how to evaluate the AG2 multi-agent pipeline\n",
+    "(architect -> coder -> reviewer) using Vertex AI Gen AI Evaluation.\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "The AG2 template implements a three-agent collaboration pipeline:\n",
+    "1. **Architect** - Designs the system architecture\n",
+    "2. **Coder** - Implements the design\n",
+    "3. **Reviewer** - Reviews and approves or requests changes\n",
+    "\n",
+    "We evaluate the pipeline on response quality and coherence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade --quiet \"ag2[gemini]\" \"google-cloud-aiplatform[evaluation]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import vertexai\n",
+    "\n",
+    "PROJECT_ID = os.environ.get(\"GOOGLE_CLOUD_PROJECT\", \"[your-project-id]\")\n",
+    "LOCATION = os.environ.get(\"GOOGLE_CLOUD_REGION\", \"us-central1\")\n",
+    "\n",
+    "vertexai.init(project=PROJECT_ID, location=LOCATION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the AG2 Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from app.agent import pattern\n",
+    "from autogen.agentchat import initiate_group_chat\n",
+    "\n",
+    "result, final_context, last_agent = initiate_group_chat(\n",
+    "    pattern=pattern,\n",
+    "    messages=\"Design and implement a REST API for a wiki service with article CRUD operations and search\",\n",
+    "    max_rounds=20,\n",
+    ")\n",
+    "\n",
+    "print(f\"Last agent: {last_agent.name}\")\n",
+    "print(f\"Messages: {len(result.chat_history)}\")\n",
+    "for msg in result.chat_history:\n",
+    "    role = msg.get('name', msg.get('role', 'unknown'))\n",
+    "    content = msg.get('content', '')[:200]\n",
+    "    print(f\"\\n--- {role} ---\")\n",
+    "    print(content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate Response Quality\n",
+    "\n",
+    "Use Vertex AI Gen AI Evaluation to assess the pipeline output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from vertexai.preview.evaluation import EvalTask\n",
+    "\n",
+    "# Collect the final response from the pipeline\n",
+    "final_response = result.chat_history[-1].get(\"content\", \"\") if result.chat_history else \"\"\n",
+    "\n",
+    "eval_data = pd.DataFrame({\n",
+    "    \"prompt\": [\n",
+    "        \"Design and implement a REST API for a wiki service with article CRUD operations and search\",\n",
+    "    ],\n",
+    "    \"response\": [final_response],\n",
+    "})\n",
+    "\n",
+    "eval_task = EvalTask(\n",
+    "    dataset=eval_data,\n",
+    "    metrics=[\"safety\", \"coherence\"],\n",
+    ")\n",
+    "\n",
+    "eval_result = eval_task.evaluate()\n",
+    "print(eval_result.summary_metrics)\n",
+    "eval_result.metrics_table"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/agent_starter_pack/agents/ag2/tests/integration/test_agent.py
+++ b/agent_starter_pack/agents/ag2/tests/integration/test_agent.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from {{cookiecutter.agent_directory}}.agent import architect, pattern
+
+from autogen.agentchat import initiate_group_chat
+
+
+def test_architect_responds() -> None:
+    """Test that the architect agent processes a message and returns a response."""
+    result = architect.run(
+        message="Design a key-value store API",
+        max_turns=3,
+    )
+
+    # Consume events to populate messages
+    for _ in result.events:
+        pass
+
+    assert result is not None
+    assert len(result.messages) > 0
+
+    has_content = any(msg.get("content") for msg in result.messages)
+    assert has_content, "Expected at least one message with content"
+
+
+def test_multi_agent_pipeline() -> None:
+    """Test the full architect -> coder -> reviewer pipeline."""
+    result, final_context, last_agent = initiate_group_chat(
+        pattern=pattern,
+        messages="Design and implement a simple key-value store with get, set, and delete operations",
+        max_rounds=20,
+    )
+
+    assert result is not None
+    # Verify we got messages from the pipeline
+    assert len(result.chat_history) > 0, "Expected conversation history from the pipeline"

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -528,6 +528,7 @@ def get_available_agents(deployment_target: str | None = None) -> dict:
         "adk_live": 2,
         "agentic_rag": 3,
         "langgraph": 4,  # displayed as "custom_a2a"
+        "ag2": 5,
         "adk_go": 0,
         "adk_java": 0,
         "adk_ts": 0,
@@ -561,6 +562,8 @@ def get_available_agents(deployment_target: str | None = None) -> dict:
                     tags = settings.get("tags", [])
                     if "langgraph" in tags:
                         framework = "langgraph"
+                    elif "ag2" in tags:
+                        framework = "ag2"
                     elif "adk" in tags:
                         framework = "adk"
                     else:

--- a/agent_starter_pack/deployment_targets/cloud_run/python/{{cookiecutter.agent_directory}}/fast_api_app.py
+++ b/agent_starter_pack/deployment_targets/cloud_run/python/{{cookiecutter.agent_directory}}/fast_api_app.py
@@ -550,6 +550,9 @@ logging_client = google_cloud_logging.Client()
 logger = logging_client.logger(__name__)
 
 
+MAX_ROUNDS_LIMIT = 20
+
+
 class PipelineRequest(BaseModel):
     """Request model for the multi-agent pipeline."""
 
@@ -557,19 +560,28 @@ class PipelineRequest(BaseModel):
     max_rounds: int = 20
 
 
+class PipelineResponse(BaseModel):
+    """Response model for the multi-agent pipeline."""
+
+    last_agent: str
+    chat_history: list[dict]
+    context: dict
+
+
 @app.post("/run")
-def run_pipeline(request: PipelineRequest) -> dict:
+def run_pipeline(request: PipelineRequest) -> PipelineResponse:
     """Run the full architect -> coder -> reviewer pipeline."""
+    capped_rounds = min(request.max_rounds, MAX_ROUNDS_LIMIT)
     result, final_context, last_agent = initiate_group_chat(
         pattern=pattern,
         messages=request.message,
-        max_rounds=request.max_rounds,
+        max_rounds=capped_rounds,
     )
-    return {
-        "last_agent": last_agent.name,
-        "chat_history": result.chat_history,
-        "context": final_context.to_dict(),
-    }
+    return PipelineResponse(
+        last_agent=last_agent.name,
+        chat_history=result.chat_history,
+        context=final_context.to_dict(),
+    )
 {% else %}
 import os
 from collections.abc import AsyncIterator

--- a/agent_starter_pack/deployment_targets/cloud_run/python/{{cookiecutter.agent_directory}}/fast_api_app.py
+++ b/agent_starter_pack/deployment_targets/cloud_run/python/{{cookiecutter.agent_directory}}/fast_api_app.py
@@ -469,6 +469,107 @@ app: FastAPI = get_fast_api_app(
 app.title = "{{cookiecutter.project_name}}"
 app.description = "API for interacting with the Agent {{cookiecutter.project_name}}"
 {%- endif %}
+{% elif cookiecutter.agent_name == "ag2" %}
+import os
+
+from a2a.server.apps import A2AFastAPIApplication
+from a2a.types import AgentSkill
+from autogen.a2a import A2aAgentServer
+from autogen.a2a.server import CardSettings
+from fastapi import FastAPI
+from google.cloud import logging as google_cloud_logging
+
+from autogen.agentchat import initiate_group_chat
+from pydantic import BaseModel
+
+from {{cookiecutter.agent_directory}}.agent import architect, coder, pattern, reviewer
+from {{cookiecutter.agent_directory}}.app_utils.telemetry import setup_telemetry
+from {{cookiecutter.agent_directory}}.app_utils.typing import Feedback
+
+setup_telemetry()
+
+# Define agent configurations with A2A skills
+AGENT_CONFIGS = {
+    "architect": {
+        "agent": architect,
+        "skills": [AgentSkill(
+            id="system_design",
+            name="System Design",
+            description="Design distributed system architecture",
+            tags=["architecture", "design"],
+            examples=["Design a REST API for a wiki service with article CRUD and search"],
+        )],
+    },
+    "coder": {
+        "agent": coder,
+        "skills": [AgentSkill(
+            id="implementation",
+            name="Code Implementation",
+            description="Implement system components from a design",
+            tags=["coding", "python"],
+            examples=["Implement the article storage module"],
+        )],
+    },
+    "reviewer": {
+        "agent": reviewer,
+        "skills": [AgentSkill(
+            id="code_review",
+            name="Code Review",
+            description="Review code for correctness and scalability",
+            tags=["review", "quality"],
+            examples=["Review this API implementation"],
+        )],
+    },
+}
+
+# Build FastAPI app with all agents mounted as A2A endpoints
+app = FastAPI(
+    title="{{cookiecutter.project_name}}",
+    description="AG2 multi-agent system with A2A protocol support",
+)
+
+for name, config in AGENT_CONFIGS.items():
+    server = A2aAgentServer(
+        config["agent"],
+        url=f"{os.getenv('APP_URL', 'http://0.0.0.0:8000')}/a2a/{name}/",
+        agent_card=CardSettings(skills=config["skills"]),
+    )
+    a2a_app = A2AFastAPIApplication(
+        agent_card=server.card,
+        extended_agent_card=server.extended_agent_card,
+        http_handler=server.build_request_handler(),
+    )
+    a2a_app.add_routes_to_app(
+        app,
+        agent_card_url=f"/a2a/{name}/.well-known/agent-card.json",
+        rpc_url=f"/a2a/{name}/",
+        extended_agent_card_url=f"/a2a/{name}/agent/authenticatedExtendedCard",
+    )
+
+logging_client = google_cloud_logging.Client()
+logger = logging_client.logger(__name__)
+
+
+class PipelineRequest(BaseModel):
+    """Request model for the multi-agent pipeline."""
+
+    message: str
+    max_rounds: int = 20
+
+
+@app.post("/run")
+def run_pipeline(request: PipelineRequest) -> dict:
+    """Run the full architect -> coder -> reviewer pipeline."""
+    result, final_context, last_agent = initiate_group_chat(
+        pattern=pattern,
+        messages=request.message,
+        max_rounds=request.max_rounds,
+    )
+    return {
+        "last_agent": last_agent.name,
+        "chat_history": result.chat_history,
+        "context": final_context.to_dict(),
+    }
 {% else %}
 import os
 from collections.abc import AsyncIterator

--- a/agent_starter_pack/deployment_targets/gke/python/{{cookiecutter.agent_directory}}/fast_api_app.py
+++ b/agent_starter_pack/deployment_targets/gke/python/{{cookiecutter.agent_directory}}/fast_api_app.py
@@ -550,6 +550,9 @@ logging_client = google_cloud_logging.Client()
 logger = logging_client.logger(__name__)
 
 
+MAX_ROUNDS_LIMIT = 20
+
+
 class PipelineRequest(BaseModel):
     """Request model for the multi-agent pipeline."""
 
@@ -557,19 +560,28 @@ class PipelineRequest(BaseModel):
     max_rounds: int = 20
 
 
+class PipelineResponse(BaseModel):
+    """Response model for the multi-agent pipeline."""
+
+    last_agent: str
+    chat_history: list[dict]
+    context: dict
+
+
 @app.post("/run")
-def run_pipeline(request: PipelineRequest) -> dict:
+def run_pipeline(request: PipelineRequest) -> PipelineResponse:
     """Run the full architect -> coder -> reviewer pipeline."""
+    capped_rounds = min(request.max_rounds, MAX_ROUNDS_LIMIT)
     result, final_context, last_agent = initiate_group_chat(
         pattern=pattern,
         messages=request.message,
-        max_rounds=request.max_rounds,
+        max_rounds=capped_rounds,
     )
-    return {
-        "last_agent": last_agent.name,
-        "chat_history": result.chat_history,
-        "context": final_context.to_dict(),
-    }
+    return PipelineResponse(
+        last_agent=last_agent.name,
+        chat_history=result.chat_history,
+        context=final_context.to_dict(),
+    )
 {% else %}
 import os
 from collections.abc import AsyncIterator

--- a/agent_starter_pack/deployment_targets/gke/python/{{cookiecutter.agent_directory}}/fast_api_app.py
+++ b/agent_starter_pack/deployment_targets/gke/python/{{cookiecutter.agent_directory}}/fast_api_app.py
@@ -469,6 +469,107 @@ app: FastAPI = get_fast_api_app(
 app.title = "{{cookiecutter.project_name}}"
 app.description = "API for interacting with the Agent {{cookiecutter.project_name}}"
 {%- endif %}
+{% elif cookiecutter.agent_name == "ag2" %}
+import os
+
+from a2a.server.apps import A2AFastAPIApplication
+from a2a.types import AgentSkill
+from autogen.a2a import A2aAgentServer
+from autogen.a2a.server import CardSettings
+from fastapi import FastAPI
+from google.cloud import logging as google_cloud_logging
+
+from autogen.agentchat import initiate_group_chat
+from pydantic import BaseModel
+
+from {{cookiecutter.agent_directory}}.agent import architect, coder, pattern, reviewer
+from {{cookiecutter.agent_directory}}.app_utils.telemetry import setup_telemetry
+from {{cookiecutter.agent_directory}}.app_utils.typing import Feedback
+
+setup_telemetry()
+
+# Define agent configurations with A2A skills
+AGENT_CONFIGS = {
+    "architect": {
+        "agent": architect,
+        "skills": [AgentSkill(
+            id="system_design",
+            name="System Design",
+            description="Design distributed system architecture",
+            tags=["architecture", "design"],
+            examples=["Design a REST API for a wiki service with article CRUD and search"],
+        )],
+    },
+    "coder": {
+        "agent": coder,
+        "skills": [AgentSkill(
+            id="implementation",
+            name="Code Implementation",
+            description="Implement system components from a design",
+            tags=["coding", "python"],
+            examples=["Implement the article storage module"],
+        )],
+    },
+    "reviewer": {
+        "agent": reviewer,
+        "skills": [AgentSkill(
+            id="code_review",
+            name="Code Review",
+            description="Review code for correctness and scalability",
+            tags=["review", "quality"],
+            examples=["Review this API implementation"],
+        )],
+    },
+}
+
+# Build FastAPI app with all agents mounted as A2A endpoints
+app = FastAPI(
+    title="{{cookiecutter.project_name}}",
+    description="AG2 multi-agent system with A2A protocol support",
+)
+
+for name, config in AGENT_CONFIGS.items():
+    server = A2aAgentServer(
+        config["agent"],
+        url=f"{os.getenv('APP_URL', 'http://0.0.0.0:8000')}/a2a/{name}/",
+        agent_card=CardSettings(skills=config["skills"]),
+    )
+    a2a_app = A2AFastAPIApplication(
+        agent_card=server.card,
+        extended_agent_card=server.extended_agent_card,
+        http_handler=server.build_request_handler(),
+    )
+    a2a_app.add_routes_to_app(
+        app,
+        agent_card_url=f"/a2a/{name}/.well-known/agent-card.json",
+        rpc_url=f"/a2a/{name}/",
+        extended_agent_card_url=f"/a2a/{name}/agent/authenticatedExtendedCard",
+    )
+
+logging_client = google_cloud_logging.Client()
+logger = logging_client.logger(__name__)
+
+
+class PipelineRequest(BaseModel):
+    """Request model for the multi-agent pipeline."""
+
+    message: str
+    max_rounds: int = 20
+
+
+@app.post("/run")
+def run_pipeline(request: PipelineRequest) -> dict:
+    """Run the full architect -> coder -> reviewer pipeline."""
+    result, final_context, last_agent = initiate_group_chat(
+        pattern=pattern,
+        messages=request.message,
+        max_rounds=request.max_rounds,
+    )
+    return {
+        "last_agent": last_agent.name,
+        "chat_history": result.chat_history,
+        "context": final_context.to_dict(),
+    }
 {% else %}
 import os
 from collections.abc import AsyncIterator


### PR DESCRIPTION
## Why

Agent Starter Pack currently supports ADK and LangGraph. AG2 is one of the most commonly used AI Agent framework with a developer community of over 20k+ people and around 400k monthly downloads. Template makes it easier to deploy AG2 based agent to GCP.


## Summary

- Add new `ag2` agent template with three specialized agents (architect,  coder, reviewer) collaborating via AG2's `DefaultPattern` with  `StringLLMCondition` handoffs
- Each agent is exposed as an individual A2A endpoint using AG2's native `A2aAgentServer`
- A `POST /run` endpoint triggers the full pipeline via `initiate_group_chat()`
- Supports `cloud_run`, `gke`, and `none` deployment targets
 
