### PR TITLE
fix: resolve enhance failures when upgrading prototype projects

### DIFF
--- a/agent_starter_pack/cli/commands/enhance.py
+++ b/agent_starter_pack/cli/commands/enhance.py
@@ -734,6 +734,16 @@ def _build_enhance_create_args(
         elif value is not False and value is not None:
             args.extend([arg_name, str(value)])
 
+    # Strip --session-type when deploying to agent_engine (it handles sessions internally)
+    if "--deployment-target" in args:
+        dt_idx = args.index("--deployment-target")
+        if dt_idx + 1 < len(args) and args[dt_idx + 1] == "agent_engine":
+            while "--session-type" in args:
+                i = args.index("--session-type")
+                args.pop(i)
+                if i < len(args) and not args[i].startswith("--"):
+                    args.pop(i)
+
     return args
 
 

--- a/agent_starter_pack/cli/utils/generation_metadata.py
+++ b/agent_starter_pack/cli/utils/generation_metadata.py
@@ -37,12 +37,10 @@ def metadata_to_cli_args(metadata: dict[str, Any]) -> list[str]:
     for key, value in create_params.items():
         if key in skip_keys:
             continue
-        if (
-            value is None
-            or value is False
-            or str(value).lower() in ("none", "skip")
-            or value == ""
-        ):
+        # "none" is a valid value for deployment_target (prototype mode)
+        if key != "deployment_target" and str(value).lower() in ("none", "skip"):
+            continue
+        if value is None or value is False or value == "":
             continue
 
         arg_name = f"--{key.replace('_', '-')}"

--- a/agent_starter_pack/cli/utils/merge.py
+++ b/agent_starter_pack/cli/utils/merge.py
@@ -80,6 +80,19 @@ def run_create_command(
             logging.error(f"Command failed: {result.stderr}")
             return False
 
+        # Verify the project was actually created (create command may
+        # silently return without generating output on validation errors)
+        expected_dir = output_dir / project_name
+        if not expected_dir.exists():
+            logging.error(
+                f"Create command succeeded but project directory not found: {expected_dir}"
+            )
+            if result.stderr:
+                logging.error(f"stderr: {result.stderr}")
+            if result.stdout:
+                logging.error(f"stdout: {result.stdout}")
+            return False
+
         return True
     except subprocess.TimeoutExpired:
         logging.error("Command timed out")

--- a/agent_starter_pack/cli/utils/upgrade.py
+++ b/agent_starter_pack/cli/utils/upgrade.py
@@ -202,8 +202,8 @@ def three_way_compare(
     old_hash = _file_hash(old_template_file)
     new_hash = _file_hash(new_template_file)
 
-    # New file in ASP
-    if current_hash is None and old_hash is None and new_hash is not None:
+    # New file in ASP (not in project, regardless of old template)
+    if current_hash is None and new_hash is not None:
         return FileCompareResult(
             path=relative_path,
             category=category,

--- a/tests/cli/commands/test_enhance.py
+++ b/tests/cli/commands/test_enhance.py
@@ -1841,6 +1841,180 @@ deployment_target = "agent_engine"
             assert "google-cloud-aiplatform" in final_pyproject
 
 
+class TestSmartMergePrototypeToDeployment:
+    """Test enhancing a prototype project (deployment_target=none) with a deployment target.
+
+    Regression tests for the bug where enhancing a prototype project to
+    agent_engine produced zero changes or incorrectly removed all files.
+    """
+
+    @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
+    def test_prototype_to_agent_engine_adds_deployment_files(
+        self, mock_create, tmp_path: pathlib.Path
+    ) -> None:
+        """Test that enhancing a prototype project to agent_engine adds new files."""
+
+        def create_template(args, output_dir, project_name, version=None):
+            del version
+            template_dir = output_dir / project_name
+            template_dir.mkdir(parents=True)
+            (template_dir / "pyproject.toml").write_text(
+                '[project]\nname = "test"\ndependencies = []'
+            )
+            (template_dir / "Makefile").write_text("# Makefile")
+            (template_dir / "README.md").write_text("# README")
+            if "--deployment-target" in args:
+                dt_idx = args.index("--deployment-target")
+                dt_value = args[dt_idx + 1] if dt_idx + 1 < len(args) else None
+            else:
+                dt_value = None
+
+            if dt_value == "agent_engine":
+                # agent_engine adds deployment files
+                deploy_dir = template_dir / "deployment"
+                deploy_dir.mkdir(parents=True)
+                (deploy_dir / "deploy.sh").write_text("#!/bin/bash\ndeploy")
+                (template_dir / "agent_engine_app.py").write_text("# AE app")
+            # Prototype (none) template has no deployment files
+            return True
+
+        mock_create.side_effect = create_template
+
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # Simulate a prototype project (deployment_target=none)
+            pyproject = pathlib.Path("pyproject.toml")
+            pyproject.write_text(
+                '[project]\nname = "test"\ndependencies = []\n\n'
+                '[tool.agent-starter-pack]\nname = "test"\n'
+                'base_template = "adk"\nasp_version = "0.30.0"\n\n'
+                "[tool.agent-starter-pack.create_params]\n"
+                'deployment_target = "none"\n'
+                'session_type = "in_memory"\n'
+            )
+            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("README.md").write_text("# README")
+            pathlib.Path("app").mkdir()
+            pathlib.Path("app/agent.py").write_text("root_agent = None")
+
+            result = runner.invoke(
+                enhance,
+                [
+                    ".",
+                    "--deployment-target",
+                    "agent_engine",
+                    "--auto-approve",
+                    "--cicd-runner",
+                    "skip",
+                    "--skip-checks",
+                ],
+            )
+
+            output = strip_ansi(result.output)
+            assert result.exit_code == 0, f"Failed with output:\n{output}"
+
+            # Deployment files should be added, not removed
+            assert pathlib.Path("agent_engine_app.py").exists()
+            assert pathlib.Path("deployment/deploy.sh").exists()
+
+            # Existing files should NOT be removed
+            assert pathlib.Path("Makefile").exists()
+            assert pathlib.Path("README.md").exists()
+
+            # Should not list any files for removal
+            assert "Files to remove" not in output
+
+    @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
+    def test_prototype_to_agent_engine_strips_session_type(
+        self, mock_create, tmp_path: pathlib.Path
+    ) -> None:
+        """Test that session_type is stripped when enhancing to agent_engine.
+
+        Prototype mode saves session_type=in_memory. Agent Engine does not
+        accept --session-type. The enhance command must strip it to avoid
+        the create command silently failing.
+        """
+        captured_args: list[list[str]] = []
+
+        def create_template(args, output_dir, project_name, version=None):
+            del version
+            captured_args.append(list(args))
+            template_dir = output_dir / project_name
+            template_dir.mkdir(parents=True)
+            (template_dir / "pyproject.toml").write_text(
+                '[project]\nname = "test"\ndependencies = []'
+            )
+            (template_dir / "Makefile").write_text("# Makefile")
+            return True
+
+        mock_create.side_effect = create_template
+
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            pyproject = pathlib.Path("pyproject.toml")
+            pyproject.write_text(
+                '[project]\nname = "test"\ndependencies = []\n\n'
+                '[tool.agent-starter-pack]\nname = "test"\n'
+                'base_template = "adk"\nasp_version = "0.30.0"\n\n'
+                "[tool.agent-starter-pack.create_params]\n"
+                'deployment_target = "none"\n'
+                'session_type = "in_memory"\n'
+            )
+            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("app").mkdir()
+            pathlib.Path("app/agent.py").write_text("root_agent = None")
+
+            runner.invoke(
+                enhance,
+                [
+                    ".",
+                    "--deployment-target",
+                    "agent_engine",
+                    "--auto-approve",
+                    "--cicd-runner",
+                    "skip",
+                    "--skip-checks",
+                ],
+            )
+
+            # The "new" template args (second call) should NOT have --session-type
+            assert len(captured_args) == 2
+            new_template_args = captured_args[1]
+            assert "--deployment-target" in new_template_args
+            assert "agent_engine" in new_template_args
+            assert "--session-type" not in new_template_args
+
+    def test_build_enhance_create_args_strips_session_for_agent_engine(self) -> None:
+        """Test _build_enhance_create_args strips session_type for agent_engine."""
+        config = {
+            "base_template": "adk",
+            "create_params": {
+                "deployment_target": "none",
+                "session_type": "in_memory",
+            },
+        }
+        overrides = {"deployment_target": "agent_engine"}
+        args = _build_enhance_create_args(config, overrides)
+        assert "--deployment-target" in args
+        assert "agent_engine" in args
+        assert "--session-type" not in args
+        assert "in_memory" not in args
+
+    def test_build_enhance_create_args_preserves_deployment_target_none(self) -> None:
+        """Test _build_enhance_create_args preserves deployment_target=none in old args."""
+        config = {
+            "base_template": "adk",
+            "create_params": {
+                "deployment_target": "none",
+            },
+        }
+        args = _build_enhance_create_args(config, None)
+        assert "--deployment-target" in args
+        assert "none" in args
+
+
 class TestSmartMergeFallback:
     """Test fallback behavior when smart-merge can't be used."""
 

--- a/tests/cli/utils/test_generation_metadata.py
+++ b/tests/cli/utils/test_generation_metadata.py
@@ -288,6 +288,23 @@ class TestMetadataSkipValues:
         assert "--frontend-type" not in args
         assert "None" not in args
 
+    def test_deployment_target_none_preserved(self) -> None:
+        """Test that deployment_target='none' is preserved (valid CLI value for prototype)."""
+        metadata = {
+            "base_template": "adk",
+            "create_params": {
+                "deployment_target": "none",
+                "cicd_runner": "skip",
+            },
+        }
+
+        args = metadata_to_cli_args(metadata)
+
+        assert "--deployment-target" in args
+        assert "none" in args
+        # cicd_runner='skip' should still be filtered
+        assert "--cicd-runner" not in args
+
 
 class TestMetadataEnablesRecreation:
     """Test that metadata is sufficient to recreate identical project scaffolding."""

--- a/tests/cli/utils/test_upgrade_utils.py
+++ b/tests/cli/utils/test_upgrade_utils.py
@@ -204,6 +204,27 @@ class TestThreeWayCompare:
         assert result.action == "new"
         assert "new file" in result.reason.lower()
 
+    def test_new_file_in_asp_with_old_template_version(
+        self, temp_dirs: tuple[pathlib.Path, pathlib.Path, pathlib.Path]
+    ) -> None:
+        """Test that a file not in the project is treated as new even if it exists in old template.
+
+        This covers the case of switching deployment targets (e.g. none -> agent_engine)
+        where the file exists in both templates with different content but not in the project.
+        """
+        project, old_template, new_template = temp_dirs
+
+        # File exists in both templates (different content) but NOT in the project
+        (old_template / "deploy_file.py").write_text("cloud_run version")
+        (new_template / "deploy_file.py").write_text("agent_engine version")
+
+        result = three_way_compare(
+            "deploy_file.py", project, old_template, new_template
+        )
+
+        assert result.action == "new"
+        assert "new file" in result.reason.lower()
+
     def test_removed_file_in_asp_user_unchanged(
         self, temp_dirs: tuple[pathlib.Path, pathlib.Path, pathlib.Path]
     ) -> None:


### PR DESCRIPTION
## Summary
- Fix `enhance -d agent_engine` producing zero changes or removing all files on prototype projects
- Preserve `deployment_target=none` in metadata (valid CLI value for prototype mode)
- Strip `--session-type` when enhancing to `agent_engine` (handles sessions internally)
- Relax new-file detection in 3-way compare to handle deployment target switches
- Add defensive check in `run_create_command` to verify project output exists

## Problem
Running `enhance -d agent_engine` on a project created with `--prototype` either:
1. Reports "0 files updated, 0 added, 0 removed" (no changes applied), or
2. Marks all project files for removal (`.gitignore`, `Makefile`, `README.md`, etc.)

Three interconnected bugs caused this:

1. **`metadata_to_cli_args` filtered `deployment_target="none"`** — the old template was regenerated with a wrong default target (`available_targets[0]`), making old and new templates identical
2. **`session_type=in_memory` carried over to `agent_engine`** — the create command silently exited (returncode 0, no output) when it saw `--session-type` with `--deployment-target agent_engine`, leaving the new template directory empty
3. **`three_way_compare` required `old_hash is None` for new files** — files present in the new template but also in the old template (different deployment target) were not detected as new when absent from the user's project

## Changes
- `generation_metadata.py`: Preserve `deployment_target="none"` instead of filtering it
- `enhance.py`: Strip `--session-type` from args when target is `agent_engine`
- `merge.py`: Verify project directory exists after create subprocess
- `upgrade.py`: Relax new-file condition to `current_hash is None and new_hash is not None`
- Added unit tests for all three fixes and integration tests for the prototype-to-deployment flow