### PR TITLE
fix(cli): honor bq_analytics config in create command

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -696,10 +696,13 @@ def create(
                 )
                 datastore = None
 
+        # Safely extract settings dictionary
+        settings = (config.get("settings") if config else None) or {}
+        if not isinstance(settings, dict):
+            settings = {}
+
         # Auto-enable data ingestion when agent requires it or --datastore is provided
-        requires_data_ingestion = config and config.get("settings", {}).get(
-            "requires_data_ingestion"
-        )
+        requires_data_ingestion = settings.get("requires_data_ingestion")
         include_data_ingestion = bool(datastore) or bool(requires_data_ingestion)
 
         if include_data_ingestion and not datastore and early_agent_language != "go":
@@ -714,6 +717,10 @@ def create(
         if debug and include_data_ingestion:
             logging.debug(f"Data ingestion enabled: {include_data_ingestion}")
             logging.debug(f"Selected datastore type: {datastore}")
+
+        # Auto-enable bq_analytics when agent requires it
+        if settings.get("bq_analytics"):
+            bq_analytics = True
 
         # Deployment target selection
         # For remote templates, we need to use the base template name for deployment target selection

--- a/tests/cli/commands/test_create.py
+++ b/tests/cli/commands/test_create.py
@@ -796,3 +796,48 @@ class TestCreateCommand:
         mock_process_template.assert_called_once()
         call_kwargs = mock_process_template.call_args[1]
         assert call_kwargs["bq_analytics"] is True
+
+    def test_create_with_bq_analytics_in_config(
+        self,
+        mock_console: MagicMock,
+        mock_verify_credentials_and_vertex: MagicMock,
+        mock_process_template: MagicMock,
+        mock_get_available_agents: MagicMock,
+        mock_get_template_path: MagicMock,
+        mock_cwd: MagicMock,
+        mock_mkdir: MagicMock,
+        mock_resolve: MagicMock,
+        mock_load_template_config: MagicMock,
+        mock_get_deployment_targets: MagicMock,
+    ) -> None:
+        """Test create command honors bq_analytics setting in template config"""
+        runner = CliRunner()
+
+        mock_get_available_agents.return_value = {
+            1: {
+                "name": "adk",
+                "description": "ADK Base Agent",
+                "language": "python",
+                "framework": "adk",
+            },
+        }
+
+        # Override mock config settings to include bq_analytics directly
+        config = mock_load_template_config.return_value
+        config["settings"]["bq_analytics"] = True
+
+        with patch("pathlib.Path.exists", return_value=False):
+            result = runner.invoke(
+                create,
+                [
+                    "test-project",
+                    "--agent",
+                    "adk",
+                    "--auto-approve",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_process_template.assert_called_once()
+        call_kwargs = mock_process_template.call_args[1]
+        assert call_kwargs["bq_analytics"] is True


### PR DESCRIPTION
## Overview
This PR updates the CLI `create.py` command to parse and honor the `bq_analytics` configuration setting whenever it's explicitly defined inside a template's configuration file (e.g., `pyproject.toml`).
## Changes Made
- **CLI Logic**: Added logic in `cli/commands/create.py` to check `config.get("settings", {}).get("bq_analytics")`. If it resolves to true, it forces `bq_analytics = True` during deployment setup. (Modeled directly after how `requires_data_ingestion` is handled).
- **Testing**: Added a new unit test `test_create_with_bq_analytics_in_config` inside `test_create.py` to guarantee this new parsing behavior is covered. 