### PR TITLE
fix: disable GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY to avoid Agent Engine crash

### DIFF
--- a/agent_starter_pack/base_templates/python/pyproject.toml
+++ b/agent_starter_pack/base_templates/python/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
 {%- if not cookiecutter.is_adk %}
     "opentelemetry-exporter-otlp-proto-http>=1.29.0,<2.0.0",
 {%- endif %}
-    # TODO: unpin once https://github.com/googleapis/python-aiplatform/issues/6451 is fixed
     "google-cloud-logging>=3.0.0,<3.12.0",
 {%- if cookiecutter.deployment_target in ('cloud_run', 'gke') %}
     "google-cloud-aiplatform[evaluation]>=1.130.0",


### PR DESCRIPTION
## Summary
- Defaults `GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY=false` in `deploy.py`, `telemetry.py`, and both terraform `service.tf` files

## Problem

When `GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY=true`, the Agent Engine runtime's `telemetry_utils.py` is injected as the `instrumentor_builder`. Its `_setup_logging` function passes both a `transport` instance and `credentials` to `LoggingServiceV2Client`, which raises a `ValueError` and prevents the agent from ever starting.

Tested across `google-cloud-aiplatform` 1.130.0, 1.138.0, and 1.141.0 — all fail with `telemetry=true`, all succeed with `telemetry=false`. The bug is in the Agent Engine server-side runtime container, not in any client version.

Upstream bug: https://github.com/googleapis/python-aiplatform/issues/6451

## Changes
- `base_templates/python/.../telemetry.py`: default to `false`
- `deployment_targets/agent_engine/.../deploy.py`: default to `false`
- `deployment_targets/agent_engine/python/deployment/terraform/service.tf`: set to `false`
- `deployment_targets/agent_engine/python/deployment/terraform/dev/service.tf`: set to `false`