### PR TITLE
fix: resolve ruff linting errors across tests and templates

### DIFF
--- a/agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/ingest_data.py
+++ b/agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/ingest_data.py
@@ -136,7 +136,9 @@ def ingest_data(
 
     # --- Step 2: Create new chunks FIRST (safe — unique timestamped IDs) ---
     created = 0
-    batch_size = min(ingestion_batch_size, 250)  # Max 250 per request for auto-embeddings
+    batch_size = min(
+        ingestion_batch_size, 250
+    )  # Max 250 per request for auto-embeddings
     for batch_start in range(0, len(df_to_create), batch_size):
         batch_end = min(batch_start + batch_size, len(df_to_create))
         batch_df = df_to_create.iloc[batch_start:batch_end]

--- a/agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/process_data.py
+++ b/agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/process_data.py
@@ -220,7 +220,9 @@ def process_data(
         str(idx) for text_chunk in df["text_chunk"] for idx in range(len(text_chunk))
     ]
     df = df.explode("text_chunk").reset_index(drop=True)
-    df["chunk_id"] = df["question_id"].astype("string") + "__" + run_ts + "__" + chunk_ids
+    df["chunk_id"] = (
+        df["question_id"].astype("string") + "__" + run_ts + "__" + chunk_ids
+    )
     logging.info("Chunk IDs created and chunks exploded.")
 
     # No embedding generation needed — Vector Search 2.0 auto-generates embeddings

--- a/tests/cicd/test_gemini_enterprise_registration.py
+++ b/tests/cicd/test_gemini_enterprise_registration.py
@@ -166,7 +166,9 @@ class TestGeminiEnterpriseRegistration:
 
                 # Create minimal deployment_metadata.json for the register command
                 metadata = {"remote_agent_engine_id": agent_engine_id}
-                with open(project_path / "deployment_metadata.json", "w") as f:
+                with open(
+                    project_path / "deployment_metadata.json", "w", encoding="utf-8"
+                ) as f:
                     json.dump(metadata, f)
 
             else:
@@ -222,7 +224,7 @@ class TestGeminiEnterpriseRegistration:
                     "deployment_metadata.json was not created"
                 )
 
-                with open(metadata_file) as f:
+                with open(metadata_file, encoding="utf-8") as f:
                     metadata = json.load(f)
 
                 agent_engine_id = metadata.get("remote_agent_engine_id")

--- a/tests/cli/commands/test_create_local.py
+++ b/tests/cli/commands/test_create_local.py
@@ -69,7 +69,7 @@ def test_create_with_local_path(
     assert "Using local template:" in result.output
 
     mock_process_template.assert_called_once()
-    call_args, call_kwargs = mock_process_template.call_args
+    _call_args, call_kwargs = mock_process_template.call_args
 
     # The template path should now be inside a temporary directory
     actual_template_path = call_kwargs["template_dir"]

--- a/tests/cli/commands/test_enhance.py
+++ b/tests/cli/commands/test_enhance.py
@@ -556,7 +556,9 @@ class TestEnhanceAgentDirectoryPrompt:
 
         with runner.isolated_filesystem():
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             with patch("agent_starter_pack.cli.commands.enhance.create"):
                 runner.invoke(
@@ -590,7 +592,7 @@ class TestEnhanceAgentDirectoryPrompt:
 
         with runner.isolated_filesystem():
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("agent = None")
+            pathlib.Path("app/agent.py").write_text("agent = None", encoding="utf-8")
 
             with patch("agent_starter_pack.cli.commands.enhance.create"):
                 runner.invoke(
@@ -1377,14 +1379,17 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             # Makefile matches old template (user didn't modify)
-            pathlib.Path("Makefile").write_text("# Original Makefile")
+            pathlib.Path("Makefile").write_text("# Original Makefile", encoding="utf-8")
 
             # Create agent directory
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1402,7 +1407,9 @@ class TestSmartMerge:
             assert result.exit_code == 0, f"Failed with output:\n{result.output}"
 
             # Verify Makefile was auto-updated
-            assert "Enhanced Makefile" in pathlib.Path("Makefile").read_text()
+            assert "Enhanced Makefile" in pathlib.Path("Makefile").read_text(
+                encoding="utf-8"
+            )
 
     @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
     def test_smart_merge_preserves_user_modified_files(
@@ -1432,12 +1439,17 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             # User modified the Makefile
-            pathlib.Path("Makefile").write_text("# My custom Makefile")
+            pathlib.Path("Makefile").write_text(
+                "# My custom Makefile", encoding="utf-8"
+            )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1455,7 +1467,9 @@ class TestSmartMerge:
             assert result.exit_code == 0, f"Failed with output:\n{result.output}"
 
             # Verify user's Makefile was preserved
-            assert "My custom Makefile" in pathlib.Path("Makefile").read_text()
+            assert "My custom Makefile" in pathlib.Path("Makefile").read_text(
+                encoding="utf-8"
+            )
 
     @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
     def test_smart_merge_detects_conflicts(
@@ -1487,12 +1501,17 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             # User modified (different from both templates)
-            pathlib.Path("Makefile").write_text("# User modified Makefile")
+            pathlib.Path("Makefile").write_text(
+                "# User modified Makefile", encoding="utf-8"
+            )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1511,7 +1530,9 @@ class TestSmartMerge:
             assert result.exit_code == 0, f"Failed with output:\n{result.output}"
             assert "Conflict" in output
             # With auto-approve and config change, new template version is preferred
-            assert "New template Makefile" in pathlib.Path("Makefile").read_text()
+            assert "New template Makefile" in pathlib.Path("Makefile").read_text(
+                encoding="utf-8"
+            )
 
     @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
     def test_smart_merge_adds_new_files(
@@ -1543,11 +1564,14 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("Makefile").write_text("# Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1597,11 +1621,14 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Original Makefile")
+            pathlib.Path("Makefile").write_text("# Original Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1620,7 +1647,9 @@ class TestSmartMerge:
             assert result.exit_code == 0, f"Failed with output:\n{result.output}"
             assert "Dry run" in output
             # Verify files were NOT modified
-            assert "Original Makefile" in pathlib.Path("Makefile").read_text()
+            assert "Original Makefile" in pathlib.Path("Makefile").read_text(
+                encoding="utf-8"
+            )
             assert not pathlib.Path("Dockerfile").exists()
 
     @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
@@ -1655,13 +1684,18 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("Makefile").write_text("# Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("# MY CUSTOM AGENT CODE")
+            pathlib.Path("app/agent.py").write_text(
+                "# MY CUSTOM AGENT CODE", encoding="utf-8"
+            )
             pathlib.Path("app/tools").mkdir()
-            pathlib.Path("app/tools/search.py").write_text("# MY CUSTOM TOOL")
+            pathlib.Path("app/tools/search.py").write_text(
+                "# MY CUSTOM TOOL", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1681,8 +1715,12 @@ class TestSmartMerge:
             assert "Skipping" in output
 
             # Verify agent code was NOT touched
-            assert "MY CUSTOM AGENT CODE" in pathlib.Path("app/agent.py").read_text()
-            assert "MY CUSTOM TOOL" in pathlib.Path("app/tools/search.py").read_text()
+            assert "MY CUSTOM AGENT CODE" in pathlib.Path("app/agent.py").read_text(
+                encoding="utf-8"
+            )
+            assert "MY CUSTOM TOOL" in pathlib.Path("app/tools/search.py").read_text(
+                encoding="utf-8"
+            )
 
     @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
     def test_smart_merge_preserves_config_files(
@@ -1714,14 +1752,19 @@ class TestSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("Makefile").write_text("# Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
             # User has config files with secrets
-            pathlib.Path(".env").write_text("API_KEY=my_secret_key")
-            pathlib.Path("config.yaml").write_text("setting: my_custom_value")
+            pathlib.Path(".env").write_text("API_KEY=my_secret_key", encoding="utf-8")
+            pathlib.Path("config.yaml").write_text(
+                "setting: my_custom_value", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1739,11 +1782,17 @@ class TestSmartMerge:
             assert result.exit_code == 0, f"Failed with output:\n{result.output}"
 
             # Verify config files were NOT modified (user secrets preserved)
-            assert "my_secret_key" in pathlib.Path(".env").read_text()
-            assert "my_custom_value" in pathlib.Path("config.yaml").read_text()
+            assert "my_secret_key" in pathlib.Path(".env").read_text(encoding="utf-8")
+            assert "my_custom_value" in pathlib.Path("config.yaml").read_text(
+                encoding="utf-8"
+            )
             # Should not contain template values
-            assert "template_key" not in pathlib.Path(".env").read_text()
-            assert "template_value" not in pathlib.Path("config.yaml").read_text()
+            assert "template_key" not in pathlib.Path(".env").read_text(
+                encoding="utf-8"
+            )
+            assert "template_value" not in pathlib.Path("config.yaml").read_text(
+                encoding="utf-8"
+            )
 
     @patch("agent_starter_pack.cli.commands.enhance.run_create_command")
     def test_smart_merge_preserves_user_dependencies(
@@ -1806,11 +1855,14 @@ asp_version = "0.30.0"
 
 [tool.agent-starter-pack.create_params]
 deployment_target = "agent_engine"
-"""
+""",
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("Makefile").write_text("# Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1828,7 +1880,7 @@ deployment_target = "agent_engine"
             assert result.exit_code == 0, f"Failed with output:\n{result.output}"
 
             # Verify dependencies were merged correctly
-            final_pyproject = pyproject.read_text()
+            final_pyproject = pyproject.read_text(encoding="utf-8")
 
             # User's custom dependencies should be preserved
             assert "my-custom-library" in final_pyproject
@@ -1891,12 +1943,15 @@ class TestSmartMergePrototypeToDeployment:
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
                 'deployment_target = "none"\n'
-                'session_type = "in_memory"\n'
+                'session_type = "in_memory"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Makefile")
-            pathlib.Path("README.md").write_text("# README")
+            pathlib.Path("Makefile").write_text("# Makefile", encoding="utf-8")
+            pathlib.Path("README.md").write_text("# README", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -1960,11 +2015,14 @@ class TestSmartMergePrototypeToDeployment:
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
                 'deployment_target = "none"\n'
-                'session_type = "in_memory"\n'
+                'session_type = "in_memory"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Makefile")
+            pathlib.Path("Makefile").write_text("# Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             runner.invoke(
                 enhance,
@@ -2038,10 +2096,13 @@ class TestSmartMergeFallback:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             with patch("agent_starter_pack.cli.commands.enhance.create") as mock_create:
                 runner.invoke(
@@ -2073,7 +2134,9 @@ class TestSmartMergeFallback:
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # No pyproject.toml - no metadata
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             with patch("agent_starter_pack.cli.commands.enhance.create") as mock_create:
                 result = runner.invoke(
@@ -2102,7 +2165,9 @@ class TestSmartMergeFallback:
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2125,7 +2190,9 @@ class TestSmartMergeFallback:
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2153,10 +2220,13 @@ class TestSmartMergeFallback:
             pyproject.write_text(
                 '[project]\nname = "test"\n\n'
                 '[tool.agent-starter-pack]\nname = "test"\n'
-                'base_template = "adk"\nasp_version = "0.30.0"\n'
+                'base_template = "adk"\nasp_version = "0.30.0"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2197,10 +2267,13 @@ class TestSmartMergeFallback:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             with patch(
                 "agent_starter_pack.cli.commands.enhance.create"
@@ -2250,11 +2323,14 @@ class TestSmartMergeFallback:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Same Makefile")
+            pathlib.Path("Makefile").write_text("# Same Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2294,10 +2370,13 @@ class TestSmartMergeFallback:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2348,10 +2427,13 @@ class TestCustomizeSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2391,10 +2473,13 @@ class TestCustomizeSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2434,10 +2519,13 @@ class TestCustomizeSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2580,10 +2668,13 @@ class TestCustomizeSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2610,10 +2701,13 @@ class TestCustomizeSmartMerge:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2659,11 +2753,14 @@ class TestSmartMergeBackup:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Original Makefile")
+            pathlib.Path("Makefile").write_text("# Original Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,
@@ -2712,11 +2809,14 @@ class TestSmartMergeBackup:
                 '[tool.agent-starter-pack]\nname = "test"\n'
                 'base_template = "adk"\nasp_version = "0.30.0"\n\n'
                 "[tool.agent-starter-pack.create_params]\n"
-                'deployment_target = "agent_engine"\n'
+                'deployment_target = "agent_engine"\n',
+                encoding="utf-8",
             )
-            pathlib.Path("Makefile").write_text("# Original Makefile")
+            pathlib.Path("Makefile").write_text("# Original Makefile", encoding="utf-8")
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 enhance,

--- a/tests/cli/commands/test_extract.py
+++ b/tests/cli/commands/test_extract.py
@@ -257,7 +257,8 @@ class TestExtractCommand:
 
         with runner.isolated_filesystem():
             # Create minimal source project
-            pathlib.Path("pyproject.toml").write_text("""
+            pathlib.Path("pyproject.toml").write_text(
+                """
 [project]
 name = "test-agent"
 
@@ -265,9 +266,13 @@ name = "test-agent"
 name = "test-agent"
 base_template = "adk"
 agent_directory = "app"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("app").mkdir()
-            pathlib.Path("app/agent.py").write_text("root_agent = None")
+            pathlib.Path("app/agent.py").write_text(
+                "root_agent = None", encoding="utf-8"
+            )
             pathlib.Path("app/__init__.py").touch()
             pathlib.Path("deployment").mkdir()
             pathlib.Path(".github").mkdir()
@@ -299,10 +304,13 @@ agent_directory = "app"
         runner = CliRunner()
 
         with runner.isolated_filesystem():
-            pathlib.Path("pyproject.toml").write_text("""
+            pathlib.Path("pyproject.toml").write_text(
+                """
 [project]
 name = "test-agent"
-""")
+""",
+                encoding="utf-8",
+            )
 
             result = runner.invoke(
                 extract,
@@ -319,13 +327,16 @@ name = "test-agent"
 
         with runner.isolated_filesystem():
             # Create source
-            pathlib.Path("pyproject.toml").write_text("""
+            pathlib.Path("pyproject.toml").write_text(
+                """
 [project]
 name = "test-agent"
 
 [tool.agent-starter-pack]
 agent_directory = "app"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("app").mkdir()
             pathlib.Path("app/agent.py").touch()
 
@@ -351,7 +362,8 @@ agent_directory = "app"
 
         with runner.isolated_filesystem():
             # Create source project
-            pathlib.Path("pyproject.toml").write_text("""
+            pathlib.Path("pyproject.toml").write_text(
+                """
 [project]
 name = "test-agent"
 dependencies = [
@@ -363,17 +375,22 @@ dependencies = [
 name = "test-agent"
 base_template = "adk"
 agent_directory = "app"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("app").mkdir()
             pathlib.Path("app/agent.py").write_text(
-                "from google.adk.agents import Agent\nroot_agent = Agent()"
+                "from google.adk.agents import Agent\nroot_agent = Agent()",
+                encoding="utf-8",
             )
             pathlib.Path("app/__init__.py").touch()
-            pathlib.Path("app/custom_module.py").write_text("# Custom code")
+            pathlib.Path("app/custom_module.py").write_text(
+                "# Custom code", encoding="utf-8"
+            )
             pathlib.Path("app/app_utils").mkdir()
             pathlib.Path("app/app_utils/telemetry.py").touch()
-            pathlib.Path("README.md").write_text("# Test Agent")
-            pathlib.Path(".gitignore").write_text(".venv/")
+            pathlib.Path("README.md").write_text("# Test Agent", encoding="utf-8")
+            pathlib.Path(".gitignore").write_text(".venv/", encoding="utf-8")
             pathlib.Path("deployment").mkdir()
             pathlib.Path("deployment/terraform").mkdir()
             pathlib.Path(".github").mkdir()
@@ -409,13 +426,16 @@ agent_directory = "app"
 
         with runner.isolated_filesystem():
             # Create source project
-            pathlib.Path("pyproject.toml").write_text("""
+            pathlib.Path("pyproject.toml").write_text(
+                """
 [project]
 name = "test-agent"
 
 [tool.agent-starter-pack]
 agent_directory = "app"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("app").mkdir()
             pathlib.Path("app/agent.py").touch()
             pathlib.Path("tests").mkdir()
@@ -438,19 +458,24 @@ agent_directory = "app"
 
         with runner.isolated_filesystem():
             # Create source
-            pathlib.Path("pyproject.toml").write_text("""
+            pathlib.Path("pyproject.toml").write_text(
+                """
 [project]
 name = "test-agent"
 
 [tool.agent-starter-pack]
 agent_directory = "app"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("app").mkdir()
             pathlib.Path("app/agent.py").touch()
 
             # Create existing output with a file
             pathlib.Path("output").mkdir()
-            pathlib.Path("output/old_file.txt").write_text("old content")
+            pathlib.Path("output/old_file.txt").write_text(
+                "old content", encoding="utf-8"
+            )
 
             result = runner.invoke(
                 extract,
@@ -637,17 +662,22 @@ class TestGoProjectExtraction:
 
         with runner.isolated_filesystem():
             # Create Go project structure
-            pathlib.Path("go.mod").write_text("module test-agent\n\ngo 1.21")
+            pathlib.Path("go.mod").write_text(
+                "module test-agent\n\ngo 1.21", encoding="utf-8"
+            )
             pathlib.Path("go.sum").touch()
-            pathlib.Path(".asp.toml").write_text("""
+            pathlib.Path(".asp.toml").write_text(
+                """
 [project]
 name = "test-go-agent"
 language = "go"
 base_template = "adk_go"
 agent_directory = "agent"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("agent").mkdir()
-            pathlib.Path("agent/agent.go").write_text("package agent")
+            pathlib.Path("agent/agent.go").write_text("package agent", encoding="utf-8")
             pathlib.Path("deployment").mkdir()
 
             result = runner.invoke(
@@ -671,19 +701,24 @@ agent_directory = "agent"
 
         with runner.isolated_filesystem():
             # Create Go project structure
-            pathlib.Path("go.mod").write_text("module test-agent\n\ngo 1.21")
-            pathlib.Path("go.sum").write_text("// checksums")
-            pathlib.Path(".asp.toml").write_text("""
+            pathlib.Path("go.mod").write_text(
+                "module test-agent\n\ngo 1.21", encoding="utf-8"
+            )
+            pathlib.Path("go.sum").write_text("// checksums", encoding="utf-8")
+            pathlib.Path(".asp.toml").write_text(
+                """
 [project]
 name = "test-go-agent"
 language = "go"
 base_template = "adk_go"
 agent_directory = "agent"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("agent").mkdir()
-            pathlib.Path("agent/agent.go").write_text("package agent")
-            pathlib.Path("README.md").write_text("# Test Agent")
-            pathlib.Path(".gitignore").write_text("bin/")
+            pathlib.Path("agent/agent.go").write_text("package agent", encoding="utf-8")
+            pathlib.Path("README.md").write_text("# Test Agent", encoding="utf-8")
+            pathlib.Path(".gitignore").write_text("bin/", encoding="utf-8")
 
             result = runner.invoke(
                 extract,
@@ -709,15 +744,20 @@ agent_directory = "agent"
 
         with runner.isolated_filesystem():
             # Create Go project
-            pathlib.Path("go.mod").write_text("module test-agent\n\ngo 1.21")
-            pathlib.Path(".asp.toml").write_text("""
+            pathlib.Path("go.mod").write_text(
+                "module test-agent\n\ngo 1.21", encoding="utf-8"
+            )
+            pathlib.Path(".asp.toml").write_text(
+                """
 [project]
 name = "test-go-agent"
 language = "go"
 agent_directory = "agent"
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("agent").mkdir()
-            pathlib.Path("agent/agent.go").write_text("package agent")
+            pathlib.Path("agent/agent.go").write_text("package agent", encoding="utf-8")
 
             runner.invoke(extract, ["output"])
 
@@ -739,7 +779,8 @@ class TestJavaProjectExtraction:
 
         with runner.isolated_filesystem():
             # Create Java project structure with ASP config in pom.xml properties
-            pathlib.Path("pom.xml").write_text("""<?xml version="1.0" encoding="UTF-8"?>
+            pathlib.Path("pom.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <groupId>myagent</groupId>
@@ -752,10 +793,12 @@ class TestJavaProjectExtraction:
     <asp.agent_directory>src/main/java</asp.agent_directory>
   </properties>
 </project>
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("src/main/java/myagent").mkdir(parents=True)
             pathlib.Path("src/main/java/myagent/RootAgent.java").write_text(
-                "package myagent;\npublic class RootAgent {}"
+                "package myagent;\npublic class RootAgent {}", encoding="utf-8"
             )
             pathlib.Path("deployment").mkdir()
 
@@ -780,7 +823,8 @@ class TestJavaProjectExtraction:
 
         with runner.isolated_filesystem():
             # Create Java project structure with ASP config in pom.xml properties
-            pathlib.Path("pom.xml").write_text("""<?xml version="1.0" encoding="UTF-8"?>
+            pathlib.Path("pom.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <groupId>myagent</groupId>
@@ -793,13 +837,15 @@ class TestJavaProjectExtraction:
     <asp.agent_directory>src/main/java</asp.agent_directory>
   </properties>
 </project>
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("src/main/java/myagent").mkdir(parents=True)
             pathlib.Path("src/main/java/myagent/RootAgent.java").write_text(
-                "package myagent;\npublic class RootAgent {}"
+                "package myagent;\npublic class RootAgent {}", encoding="utf-8"
             )
-            pathlib.Path("README.md").write_text("# Test Agent")
-            pathlib.Path(".gitignore").write_text("target/")
+            pathlib.Path("README.md").write_text("# Test Agent", encoding="utf-8")
+            pathlib.Path(".gitignore").write_text("target/", encoding="utf-8")
 
             result = runner.invoke(
                 extract,
@@ -823,7 +869,8 @@ class TestJavaProjectExtraction:
 
         with runner.isolated_filesystem():
             # Create Java project with ASP config in pom.xml properties
-            pathlib.Path("pom.xml").write_text("""<?xml version="1.0" encoding="UTF-8"?>
+            pathlib.Path("pom.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <groupId>myagent</groupId>
@@ -835,10 +882,12 @@ class TestJavaProjectExtraction:
     <asp.agent_directory>src/main/java</asp.agent_directory>
   </properties>
 </project>
-""")
+""",
+                encoding="utf-8",
+            )
             pathlib.Path("src/main/java/myagent").mkdir(parents=True)
             pathlib.Path("src/main/java/myagent/RootAgent.java").write_text(
-                "package myagent;\npublic class RootAgent {}"
+                "package myagent;\npublic class RootAgent {}", encoding="utf-8"
             )
 
             runner.invoke(extract, ["output"])

--- a/tests/integration/test_makefile_usability.py
+++ b/tests/integration/test_makefile_usability.py
@@ -124,7 +124,7 @@ def validate_makefile_usability(
         mock_bin = tempfile.mkdtemp(prefix="mock_bin_")
         for cmd in ("npm", "npx", "tsc", "vite"):
             mock_path = os.path.join(mock_bin, cmd)
-            with open(mock_path, "w") as f:
+            with open(mock_path, "w", encoding="utf-8") as f:
                 f.write("#!/bin/sh\nexit 0\n")
             os.chmod(mock_path, stat.S_IRWXU)
         mock_env = {**os.environ, "PATH": f"{mock_bin}:{os.environ['PATH']}"}

--- a/tests/unit/test_makefile_template.py
+++ b/tests/unit/test_makefile_template.py
@@ -411,14 +411,16 @@ class TestMakefileGeneration:
 
         # Load or create hash registry
         if hash_file.exists():
-            hashes = json.loads(hash_file.read_text())
+            hashes = json.loads(hash_file.read_text(encoding="utf-8"))
         else:
             hashes = {}
 
         if config_name not in hashes:
             # Save new hash
             hashes[config_name] = output_hash
-            hash_file.write_text(json.dumps(hashes, indent=2, sort_keys=True))
+            hash_file.write_text(
+                json.dumps(hashes, indent=2, sort_keys=True), encoding="utf-8"
+            )
             pytest.skip(f"Created new hash for {config_name}")
 
         # Compare hashes
@@ -644,13 +646,15 @@ class TestGoMakefileGeneration:
         output_hash = hashlib.sha256(output.encode()).hexdigest()
 
         if hash_file.exists():
-            hashes = json.loads(hash_file.read_text())
+            hashes = json.loads(hash_file.read_text(encoding="utf-8"))
         else:
             hashes = {}
 
         if config_name not in hashes:
             hashes[config_name] = output_hash
-            hash_file.write_text(json.dumps(hashes, indent=2, sort_keys=True))
+            hash_file.write_text(
+                json.dumps(hashes, indent=2, sort_keys=True), encoding="utf-8"
+            )
             pytest.skip(f"Created new hash for {config_name}")
 
         expected_hash = hashes[config_name]
@@ -727,13 +731,15 @@ class TestJavaMakefileGeneration:
         output_hash = hashlib.sha256(output.encode()).hexdigest()
 
         if hash_file.exists():
-            hashes = json.loads(hash_file.read_text())
+            hashes = json.loads(hash_file.read_text(encoding="utf-8"))
         else:
             hashes = {}
 
         if config_name not in hashes:
             hashes[config_name] = output_hash
-            hash_file.write_text(json.dumps(hashes, indent=2, sort_keys=True))
+            hash_file.write_text(
+                json.dumps(hashes, indent=2, sort_keys=True), encoding="utf-8"
+            )
             pytest.skip(f"Created new hash for {config_name}")
 
         expected_hash = hashes[config_name]


### PR DESCRIPTION
## Summary
- Add missing `encoding` argument to all `open`, `read_text`, and `write_text` calls in test files (`PLW1514`)
- Fix unused unpacked variable in `test_create_local.py` (`RUF059`)
- Reformat two `agentic_rag` data ingestion template files to satisfy `ruff format`

## Changes
- `tests/cicd/test_gemini_enterprise_registration.py`
- `tests/cli/commands/test_create_local.py`
- `tests/cli/commands/test_enhance.py`
- `tests/cli/commands/test_extract.py`
- `tests/integration/test_makefile_usability.py`
- `tests/unit/test_makefile_template.py`
- `agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/ingest_data.py`
- `agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/process_data.py`