### PR TITLE
fix: use valid model name for Vertex AI connectivity check

### DIFF
--- a/agent_starter_pack/cli/utils/gcp.py
+++ b/agent_starter_pack/cli/utils/gcp.py
@@ -120,7 +120,7 @@ def _test_vertex_connection(
 
     try:
         response = requests.post(
-            f"https://us-central1-aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/publishers/google/models/gemini-3-flash-preview:countTokens",
+            f"https://us-central1-aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global/publishers/google/models/gemini-2.5-flash:countTokens",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Replace `gemini-3-flash-preview` with `gemini-2.5-flash` in `_test_vertex_connection`

## Problem
The `_test_vertex_connection` function uses `gemini-3-flash-preview` for the countTokens API call, but this model doesn't exist in the countTokens endpoint — the API returns 404.

## Solution
Use `gemini-2.5-flash`, which is available on the countTokens endpoint and returns 200.