### PR TITLE
fix: align process_data timestamps to UTC

### DIFF
--- a/agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/process_data.py
+++ b/agent_starter_pack/agents/agentic_rag/data_ingestion/data_ingestion_pipeline/components/process_data.py
@@ -62,7 +62,7 @@ def process_data(
         location: BigQuery location
     """
     import logging
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     import bigframes.pandas as bpd
     import swifter
@@ -89,7 +89,7 @@ def process_data(
         logging.warning(
             "Pipeline schedule not set. Setting schedule_time to current date."
         )
-        schedule_time_dt = datetime.now()
+        schedule_time_dt = datetime.now(timezone.utc)
 
     # Note: The following line sets the schedule time 5 years back to allow sample data to be present.
     # For your use case, please comment out the following line to use the actual schedule time.
@@ -215,7 +215,7 @@ def process_data(
     # This allows create-before-delete ingestion: new chunks never collide
     # with old ones, so we can safely create first, then delete stale data.
     logging.info("Creating chunk IDs and exploding chunks into rows...")
-    run_ts = datetime.now().strftime("%Y%m%d%H%M%S")
+    run_ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
     chunk_ids = [
         str(idx) for text_chunk in df["text_chunk"] for idx in range(len(text_chunk))
     ]
@@ -226,7 +226,7 @@ def process_data(
     logging.info("Chunk IDs created and chunks exploded.")
 
     # No embedding generation needed — Vector Search 2.0 auto-generates embeddings
-    df = df.assign(creation_timestamp=datetime.now())
+    df = df.assign(creation_timestamp=datetime.now(timezone.utc))
 
     # Store results in BigQuery
     PARTITION_DATE_COLUMN = "creation_timestamp"


### PR DESCRIPTION
## Summary
- Aligns all `datetime.now()` calls in `process_data` to use `timezone.utc`, matching the existing `datetime.now(timezone.utc)` in `ingest_data`
- Prevents chunks from falling outside the `look_back_days` window when containers run in non-UTC timezones

## Context
Follow-up to #878. The timezone mismatch was flagged during review — `process_data` wrote naive `creation_timestamp` values while `ingest_data` used UTC-aware cutoff filters.

## Changes
- `process_data.py`: Import `timezone`, update 3 `datetime.now()` calls to `datetime.now(timezone.utc)`

## Test plan
- [x] Verify pipeline runs correctly with UTC timestamps
- [x] Confirm chunks created by `process_data` fall within `ingest_data`'s look_back_days window