### PR TITLE
feat: Add vertical skills plugin support

### DIFF
--- a/agent_starter_pack/cli/commands/create.py
+++ b/agent_starter_pack/cli/commands/create.py
@@ -605,7 +605,95 @@ def create(
         if debug:
             logging.debug(f"Selected agent: {final_agent}")
 
-        # Load template configuration based on whether it's remote or local
+        # Check if selected agent is a vertical skill plugin
+        from ..utils.template import is_vertical_skill_agent, get_vertical_skill_config
+
+        is_vertical = is_vertical_skill_agent(final_agent)
+
+        if is_vertical:
+            console.print(f"\n[bold cyan]Using vertical skill: {final_agent}[/]")
+
+            # Get vertical skill configuration
+            skill_config = get_vertical_skill_config(final_agent)
+
+            if not skill_config:
+                raise click.ClickException(f"Failed to load vertical skill: {final_agent}")
+
+            skill_instance = skill_config.get("skill_instance")
+            interview_questions = skill_config.get("interview_questions", [])
+
+            # Run vertical skill interview
+            if interview_questions:
+                interview_responses = run_vertical_skill_interview(
+                    questions=interview_questions,
+                    skill_name=skill_config["display_name"],
+                    auto_approve=auto_approve
+                )
+
+                if debug:
+                    logging.debug(f"Interview responses: {interview_responses}")
+
+                # Process interview responses to template variables
+                try:
+                    vertical_skill_vars = skill_instance.process_interview_responses(interview_responses)
+
+                    if debug:
+                        logging.debug(f"Processed template vars: {vertical_skill_vars}")
+
+                    # Merge vertical skill vars into cookiecutter context
+                    if not cli_overrides:
+                        cli_overrides = {}
+
+                    cli_overrides["vertical_skill_vars"] = vertical_skill_vars
+
+                    console.print(f"[green]✓ Processed interview responses[/]")
+
+                except Exception as e:
+                    console.print(f"Error processing interview responses: {e}", style="bold red")
+                    if debug:
+                        logging.exception("Interview processing failed")
+                    raise
+
+            # Use vertical skill's template path
+            # Vertical skills are complete cookiecutter templates - use them directly
+            template_path = pathlib.Path(skill_config["template_path"])
+
+            if debug:
+                logging.debug(f"Using vertical skill template: {template_path}")
+
+            # For vertical skills, call cookiecutter directly and skip process_template
+            from cookiecutter.main import cookiecutter
+
+            # Merge vertical skill vars into cookiecutter extra_context
+            extra_context = {"project_name": project_name}
+            if cli_overrides and "vertical_skill_vars" in cli_overrides:
+                extra_context.update(cli_overrides["vertical_skill_vars"])
+
+            if debug:
+                logging.debug(f"Calling cookiecutter with template: {template_path}")
+                logging.debug(f"Extra context: {extra_context}")
+
+            # Always print to see what we're passing
+            console.print(f"[dim]Extra context keys: {list(extra_context.keys())}[/]")
+
+            # Call cookiecutter directly
+            output_path = cookiecutter(
+                str(template_path),
+                no_input=True,
+                extra_context=extra_context,
+                output_dir=str(destination_dir)
+            )
+
+            console.print("\n[bold green]Success![/] Your agent project is ready.\n")
+            console.print("[bold cyan]Documentation[/]")
+            console.print(f"   README:    [cyan]cat {project_name}/README.md[/]")
+            console.print(f"   Dev Guide: [cyan][link=https://goo.gle/asp-dev]https://goo.gle/asp-dev[/link][/cyan]")
+            console.print("\n[bold cyan]Get Started[/]")
+            console.print(f"   [bold bright_green]cd {project_name} && make install && make playground[/]")
+
+            return  # Skip the rest of the create flow
+
+        # Load template configuration based on whether it's remote, local, or vertical skill
         # Track original base template to detect actual overrides (not just selection)
         original_base_template: str | None = None
         if template_source_path:
@@ -931,7 +1019,7 @@ def create(
         # Process template
         if not template_source_path:
             template_path = get_template_path(final_agent, debug=debug)
-        # template_path is already set above for remote templates
+        # template_path is already set above for remote templates (including vertical skills)
 
         if debug:
             logging.debug(f"Template path: {template_path}")
@@ -1159,12 +1247,29 @@ def display_agent_selection(
                 header = "\U0001f310 Other Languages"
             console.print(f"\n  [bold cyan]{header}[/]")
 
+        # Skip vertical skills in main display - they get their own section
+        if agent.get("is_vertical_skill"):
+            continue
+
         # Align agent names for cleaner display (use display_name if available)
         display_name = agent.get("display_name", agent["name"])
         name_padded = display_name.ljust(14)
         console.print(
             f"     {num}. [bold]{name_padded}[/] [dim]{agent['description']}[/]"
         )
+
+    # Display vertical skill plugins
+    vertical_skills = {num: agent for num, agent in agents.items() if agent.get("is_vertical_skill")}
+
+    if vertical_skills:
+        console.print(f"\n  [bold cyan]🎯 Vertical Skills (Domain-Specific)[/]")
+
+        for num, agent in vertical_skills.items():
+            display_name = agent.get("display_name", agent["name"])
+            name_padded = display_name.ljust(14)
+            console.print(
+                f"     {num}. [bold]{name_padded}[/] [dim]{agent['description']}[/]"
+            )
 
     # Add "More Options" submenu entry
     more_options_num = len(agents) + 1
@@ -1191,6 +1296,65 @@ def display_agent_selection(
         return AgentSelectionResult(agent=agents[choice]["name"])
     else:
         raise ValueError(f"Invalid agent selection: {choice}")
+
+
+def run_vertical_skill_interview(
+    questions: list[dict],
+    skill_name: str,
+    auto_approve: bool = False
+) -> dict:
+    """Run vertical skill interview questions."""
+    responses = {}
+
+    console.print(f"\n[bold cyan]Running {skill_name} Interview[/]")
+    console.print(f"[dim]{len(questions)} domain-specific questions[/]\n")
+
+    for idx, question in enumerate(questions, 1):
+        number = question.get("number", f"Q{idx-1}")
+        title = question.get("title", "Question")
+        question_text = question.get("question", "")
+        options = question.get("options", [])
+        default = question.get("default", "1")
+
+        console.print(f"\n[bold]{number}: {title}[/]")
+        console.print(f"{question_text}\n")
+
+        for option in options:
+            console.print(f"  {option}")
+
+        if auto_approve:
+            answer = default
+            console.print(f"> Using default: [yellow]{default}[/]", style="dim")
+        else:
+            valid_choices = [opt.split(".")[0].strip() for opt in options if "." in opt]
+
+            answer = Prompt.ask(
+                "\nYour choice",
+                choices=valid_choices if valid_choices else None,
+                default=default
+            )
+
+        response_key = _question_number_to_response_key(number)
+        responses[response_key] = answer
+
+    console.print(f"\n[green]✓ Interview complete![/]")
+    return responses
+
+
+def _question_number_to_response_key(question_number: str) -> str:
+    """Map question number (Q0, Q1, etc.) to response key."""
+    mapping = {
+        "Q0": "gate_question",
+        "Q1": "product_fields_label",
+        "Q2": "data_source",
+        "Q3": "search_type",
+        "Q4": "embedding_model",
+        "Q5": "catalog_size",
+        "Q6": "search_ui",
+        "Q7": "cart_action",
+        "Q8": "vague_query_behavior",
+    }
+    return mapping.get(question_number, question_number.lower().replace("q", "question_"))
 
 
 def display_more_options_submenu(

--- a/agent_starter_pack/cli/utils/plugin_discovery.py
+++ b/agent_starter_pack/cli/utils/plugin_discovery.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discover and load vertical skill plugins for agent-starter-pack.
+
+This module enables agent-starter-pack to discover and load vertical skills
+(domain-specific agent templates) that are installed as plugins via Python
+entry points.
+
+Vertical skills extend agent-starter-pack with specialized use cases like:
+- Product search agents (e-commerce)
+- Customer support agents
+- Data science agents
+- And more...
+
+Installation:
+    pip install vertical-skills
+
+Usage:
+    from agent_starter_pack.cli.utils.plugin_discovery import load_vertical_skill_plugins
+
+    skills = load_vertical_skill_plugins()
+    for skill_name, skill_config in skills.items():
+        print(f"Found skill: {skill_config['display_name']}")
+"""
+
+import importlib.metadata
+import logging
+from typing import Dict, Any, List
+from pathlib import Path
+from rich.console import Console
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+
+def load_vertical_skill_plugins() -> Dict[str, Any]:
+    """Discover and load vertical skill plugins via Python entry points.
+
+    Discovers plugins registered under the 'agent_starter_pack.skills' entry point.
+    Each plugin must implement the VerticalSkill protocol providing:
+    - name: Unique skill identifier
+    - display_name: Human-readable name
+    - description: Brief description
+    - template_path: Path to cookiecutter templates
+    - get_interview_questions(): Domain-specific interview questions
+    - process_interview_responses(): Convert responses to template variables
+
+    Returns:
+        Dictionary mapping skill names to skill configurations with:
+        - name: Skill identifier
+        - display_name: Display name
+        - description: Description
+        - template_path: Path to templates
+        - interview_questions: List of questions
+        - is_vertical_skill: True (flag for vertical skills)
+        - plugin_name: Entry point name
+        - skill_instance: Plugin instance
+
+    Example:
+        >>> skills = load_vertical_skill_plugins()
+        >>> if 'product_search' in skills:
+        ...     skill = skills['product_search']
+        ...     print(skill['display_name'])  # "Product Search Agent"
+        ...     questions = skill['interview_questions']
+        ...     instance = skill['skill_instance']
+    """
+    skills = {}
+
+    try:
+        # Get all entry points for agent_starter_pack.skills
+        entry_points = importlib.metadata.entry_points()
+
+        # Python 3.10+ uses select(), Python 3.9 uses get()
+        if hasattr(entry_points, 'select'):
+            skill_entry_points = entry_points.select(group="agent_starter_pack.skills")
+        else:
+            # Python 3.9 fallback
+            skill_entry_points = entry_points.get("agent_starter_pack.skills", [])
+
+        logger.debug(f"Discovered {len(list(skill_entry_points))} skill entry points")
+
+        for entry_point in skill_entry_points:
+            try:
+                logger.debug(f"Loading plugin: {entry_point.name}")
+
+                # Load the register function from the entry point
+                register_func = entry_point.load()
+
+                # Call register() to get the skill instance
+                skill = register_func()
+
+                # Validate skill has required attributes
+                required_attrs = ['name', 'display_name', 'description', 'template_path']
+                for attr in required_attrs:
+                    if not hasattr(skill, attr):
+                        raise AttributeError(f"Skill missing required attribute: {attr}")
+
+                # Load interview questions
+                try:
+                    interview_questions = skill.get_interview_questions()
+                except Exception as e:
+                    logger.warning(f"Failed to load questions for {skill.name}: {e}")
+                    interview_questions = []
+
+                # Add to available skills
+                skills[skill.name] = {
+                    "name": skill.name,
+                    "display_name": skill.display_name,
+                    "description": skill.description,
+                    "template_path": skill.template_path,
+                    "interview_questions": interview_questions,
+                    "is_vertical_skill": True,
+                    "plugin_name": entry_point.name,
+                    "skill_instance": skill,  # Keep reference for later use
+                    "language": "python",  # Vertical skills are Python-based
+                }
+
+                logger.info(f"✓ Loaded vertical skill plugin: {skill.name}")
+                console.print(
+                    f"  Loaded vertical skill: [cyan]{skill.display_name}[/]",
+                    style="dim"
+                )
+
+            except Exception as e:
+                console.print(
+                    f"  Warning: Failed to load skill plugin '{entry_point.name}': {e}",
+                    style="yellow"
+                )
+                logger.warning(f"Plugin load failed: {entry_point.name}", exc_info=True)
+
+    except Exception as e:
+        logger.warning(f"Failed to discover skill plugins: {e}", exc_info=True)
+
+    if skills:
+        logger.info(f"Loaded {len(skills)} vertical skill plugin(s)")
+
+    return skills
+
+
+def get_vertical_skill_by_name(skill_name: str) -> Any:
+    """Get a specific vertical skill plugin by name.
+
+    Args:
+        skill_name: Name of the skill to load
+
+    Returns:
+        Skill instance or None if not found
+
+    Example:
+        >>> skill = get_vertical_skill_by_name('product_search')
+        >>> if skill:
+        ...     questions = skill.get_interview_questions()
+    """
+    skills = load_vertical_skill_plugins()
+    if skill_name in skills:
+        return skills[skill_name]['skill_instance']
+    return None
+
+
+def list_vertical_skills() -> List[Dict[str, str]]:
+    """List all available vertical skills with their metadata.
+
+    Returns:
+        List of dictionaries with name, display_name, and description
+
+    Example:
+        >>> for skill in list_vertical_skills():
+        ...     print(f"{skill['display_name']}: {skill['description']}")
+    """
+    skills = load_vertical_skill_plugins()
+    return [
+        {
+            "name": config["name"],
+            "display_name": config["display_name"],
+            "description": config["description"],
+        }
+        for config in skills.values()
+    ]
+
+
+def is_vertical_skill(agent_name: str) -> bool:
+    """Check if an agent name corresponds to a vertical skill plugin.
+
+    Args:
+        agent_name: Name of the agent to check
+
+    Returns:
+        True if agent is a vertical skill plugin, False otherwise
+
+    Example:
+        >>> if is_vertical_skill('product_search'):
+        ...     print("This is a vertical skill")
+    """
+    skills = load_vertical_skill_plugins()
+    return agent_name in skills

--- a/agent_starter_pack/cli/utils/template.py
+++ b/agent_starter_pack/cli/utils/template.py
@@ -40,6 +40,7 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 from agent_starter_pack.cli.utils.version import get_current_version
 
 from .datastores import DATASTORES
+from .plugin_discovery import load_vertical_skill_plugins
 from .remote_template import (
     get_base_template_name,
     render_and_merge_makefiles,
@@ -600,7 +601,59 @@ def get_available_agents(deployment_target: str | None = None) -> dict:
     # Convert to numbered dictionary starting from 1
     agents = {i + 1: agent for i, agent in enumerate(agents_list)}
 
+    # Load vertical skill plugins
+    try:
+        vertical_skills = load_vertical_skill_plugins()
+        # Add vertical skills to agents dict starting from next number
+        next_number = len(agents) + 1
+        for skill_name, skill_config in vertical_skills.items():
+            agents[next_number] = {
+                "name": skill_name,
+                "display_name": skill_config.get("display_name", skill_name),
+                "description": skill_config.get("description", ""),
+                "language": "python",  # Vertical skills are Python-based
+                "framework": "vertical_skill",
+                "priority": 999,  # Display after built-in agents
+                "is_vertical_skill": True,
+                "skill_config": skill_config,
+            }
+            next_number += 1
+    except Exception as e:
+        logging.warning(f"Failed to load vertical skill plugins: {e}")
+
     return agents
+
+
+def is_vertical_skill_agent(agent_name: str) -> bool:
+    """Check if an agent is a vertical skill plugin.
+
+    Args:
+        agent_name: Name of the agent
+
+    Returns:
+        True if agent is a vertical skill, False otherwise
+    """
+    try:
+        vertical_skills = load_vertical_skill_plugins()
+        return agent_name in vertical_skills
+    except Exception:
+        return False
+
+
+def get_vertical_skill_config(agent_name: str) -> dict[str, Any] | None:
+    """Get configuration for a vertical skill plugin.
+
+    Args:
+        agent_name: Name of the vertical skill
+
+    Returns:
+        Skill configuration dictionary or None if not found
+    """
+    try:
+        vertical_skills = load_vertical_skill_plugins()
+        return vertical_skills.get(agent_name)
+    except Exception:
+        return None
 
 
 def load_template_config(template_dir: pathlib.Path) -> dict[str, Any]:
@@ -1460,8 +1513,12 @@ def process_template(
                 generate_java_package_vars(project_name) if language == "java" else {}
             )
 
+            # Compute project_slug from project_name (for vertical skill compatibility)
+            project_slug = project_name.lower().replace(' ', '-').replace('_', '-')
+
             cookiecutter_config = {
                 "project_name": project_name,
+                "project_slug": project_slug,
                 "agent_name": agent_name,
                 "package_version": get_current_version(),
                 "generated_at": datetime.now(tz=UTC).isoformat(),
@@ -1516,6 +1573,12 @@ def process_template(
                     "Makefile",  # Don't render Makefile - handled by render_and_merge_makefiles
                 ],
             }
+
+            # Merge vertical skill variables if present
+            if cli_overrides and "vertical_skill_vars" in cli_overrides:
+                vertical_skill_vars = cli_overrides["vertical_skill_vars"]
+                cookiecutter_config.update(vertical_skill_vars)
+                logging.debug(f"Merged vertical skill variables into cookiecutter config: {list(vertical_skill_vars.keys())}")
 
             with open(
                 cookiecutter_template / "cookiecutter.json", "w", encoding="utf-8"


### PR DESCRIPTION
  - Add plugin_discovery.py for entry point-based plugin loading
  - Extend create.py to support vertical skill interview workflow
  - Extend template.py to discover and integrate vertical skills
  - 100% backward compatible with existing agents

  Total changes: ~368 lines added across 3 files