### PR TITLE
chore: remove vertex-agent-garden labels from deploy.py

### DIFF
--- a/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -385,15 +385,6 @@ def deploy_agent_engine_app(
     )
     vertexai.init(project=project, location=location)
 
-    # Add agent garden labels if configured
-{%- if cookiecutter.agent_garden %}
-{%- if cookiecutter.agent_sample_id and cookiecutter.agent_sample_publisher %}
-    labels_dict["vertex-agent-sample-id"] = "{{cookiecutter.agent_sample_id}}"
-    labels_dict["vertex-agent-sample-publisher"] = "{{cookiecutter.agent_sample_publisher}}"
-    labels_dict["deployed-with"] = "agent-garden"
-{%- endif %}
-{%- endif %}
-
     # Dynamically import the agent instance to generate class_methods
     logging.info(f"Importing {entrypoint_module}.{entrypoint_object}")
     module = importlib.import_module(entrypoint_module)

--- a/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
+++ b/agent_starter_pack/deployment_targets/agent_engine/python/{{cookiecutter.agent_directory}}/app_utils/deploy.py
@@ -385,6 +385,10 @@ def deploy_agent_engine_app(
     )
     vertexai.init(project=project, location=location)
 
+{%- if cookiecutter.agent_garden %}
+    labels_dict["deployed-with"] = "agent-garden"
+{%- endif %}
+
     # Dynamically import the agent instance to generate class_methods
     logging.info(f"Importing {entrypoint_module}.{entrypoint_object}")
     module = importlib.import_module(entrypoint_module)


### PR DESCRIPTION
## Summary
- Remove the agent garden label block from the Agent Engine deploy script
- Labels removed: `vertex-agent-sample-id`, `vertex-agent-sample-publisher`, `deployed-with`