### PR TITLE
docs: announce agents-cli as the next evolution of Agent Starter Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@
   </picture>
 </a> [![Launch in Cloud Shell](https://img.shields.io/badge/Launch-in_Cloud_Shell-white)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Feliasecchig%2Fasp-open-in-cloud-shell&cloudshell_print=open-in-cs) ![Stars](https://img.shields.io/github/stars/GoogleCloudPlatform/agent-starter-pack?color=yellow)
 
+> ## 📣 Agents CLI is here
+>
+> **[`agents-cli`](https://github.com/google/agents-cli)** is the next evolution of Agent Starter Pack — the unified CLI and skills for building, evaluating, deploying, and operating agents on Google Cloud's Agent Platform. It works with Claude Code, Gemini CLI, Codex, and any other coding agent.
+>
+> ```bash
+> uvx google-agents-cli setup
+> ```
+>
+> **Already on ASP? Migration takes minutes** — your agent code, tests, Terraform, and CI/CD all carry over with no rewrites.
+>
+> **What you gain:**
+> - 🛠️ **Unified CLI** in place of the Makefile — `run`, `deploy`, `eval run`, `eval compare`, `playground`, `lint`, and more
+> - 🧠 **Bundled coding-agent skills** that turn Claude Code, Gemini CLI, or Codex into an ADK expert
+> - 🔁 **End-to-end lifecycle tooling**: scaffold → eval → deploy → publish → observe
+>
+> **→ [Migration guide](https://google.github.io/agents-cli/reference/from-agent-starter-pack/)** &nbsp;•&nbsp; [Get started](https://google.github.io/agents-cli/) &nbsp;•&nbsp; [Docs](https://google.github.io/agents-cli/) &nbsp;•&nbsp; [GitHub](https://github.com/google/agents-cli) &nbsp;•&nbsp; [PyPI](https://pypi.org/project/google-agents-cli/)
+>
+> **Agent Starter Pack will no longer receive new features.** All future development happens in `agents-cli`.
+
+---
+
 A Python package that provides **production-ready templates** for GenAI agents on Google Cloud.
 
 Focus on your agent logic—the starter pack provides everything else: infrastructure, CI/CD, observability, and security.

--- a/agent_starter_pack/cli/utils/logging.py
+++ b/agent_starter_pack/cli/utils/logging.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import importlib.metadata
-import random
 import sys
 from collections.abc import Callable
 from functools import wraps
@@ -24,17 +23,6 @@ from rich.panel import Panel
 from rich.table import Table
 
 console = Console()
-
-MOTTOS = [
-    "Your agents are cleared for takeoff.",
-    "Launching agents into production, one deploy at a time.",
-    "Houston, we have an agent.",
-    "To production... and beyond!",
-    "One small step for code, one giant leap for agents.",
-    "Fueling your AI agents with Google Cloud.",
-    "3... 2... 1... Agent deployed!",
-    "The sky is not the limit when you have agents.",
-]
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -47,7 +35,7 @@ def _get_version() -> str:
         return "dev"
 
 
-def _build_banner(line1: str, version: str, motto: str) -> Panel:
+def _build_banner(line1: str, version: str, include_announcement: bool = True) -> Panel:
     """Build a compact banner panel with ASP ASCII art logo."""
     a = "bold blue"
     s = "bold cyan"
@@ -57,7 +45,18 @@ def _build_banner(line1: str, version: str, motto: str) -> Panel:
         f"[{a}]█▀█[/] [{s}]▀▀█[/] [{p}]█▀▀[/]\n"
         f"[{a}]▀ ▀[/] [{s}]▀▀▀[/] [{p}]▀[/]  "
     )
-    right_text = f' [italic dim]"{motto}"[/]\n\n {line1}'
+    sections = []
+    if line1:
+        sections.append(f" {line1}")
+    if include_announcement:
+        sections.append(
+            " [bold]📣 Agents CLI is here[/] ([bold]goo.gle/agents-cli[/]) —"
+            " the next evolution of Agent Starter Pack."
+            "\n → Try it: [bold]uvx google-agents-cli setup[/]"
+            "\n → Migrate in minutes:"
+            " https://google.github.io/agents-cli/reference/from-agent-starter-pack/"
+        )
+    right_text = "\n\n".join(sections)
     table = Table(
         show_header=False,
         show_edge=False,
@@ -99,25 +98,20 @@ def display_welcome_banner(
         console.print(f"[bold blue]Agent Starter Pack[/] [dim]v{version}[/]")
         return
 
-    motto = random.choice(MOTTOS)
-
     if enhance_mode:
         panel = _build_banner(
             line1="Enhancing your project with production-ready capabilities!",
             version=version,
-            motto=motto,
         )
     elif setup_cicd_mode:
         panel = _build_banner(
             line1="Setting up CI/CD infrastructure for your agent!",
             version=version,
-            motto=motto,
         )
     elif register_mode:
         panel = _build_banner(
             line1="Registering your agent to Gemini Enterprise!",
             version=version,
-            motto=motto,
         )
     elif agent_garden:
         panel = _build_banner(
@@ -126,7 +120,7 @@ def display_welcome_banner(
                 "Google Cloud - Agent Starter Pack[/link]"
             ),
             version=version,
-            motto=motto,
+            include_announcement=False,
         )
     elif agent and (agent.startswith("adk@") or agent.startswith("adk-py@")):
         panel = _build_banner(
@@ -135,13 +129,12 @@ def display_welcome_banner(
                 "Google Cloud - Agent Starter Pack[/link]"
             ),
             version=version,
-            motto=motto,
+            include_announcement=False,
         )
     else:
         panel = _build_banner(
-            line1="Create production-ready AI agents on Google Cloud!",
+            line1="",
             version=version,
-            motto=motto,
         )
 
     console.print()


### PR DESCRIPTION
## Summary
- Add a banner to the top of the README announcing `agents-cli` (the unified CLI and skills for building, evaluating, deploying, and operating agents on Google Cloud's Agent Platform) as the next evolution of Agent Starter Pack, with the install command, the migration story, what users gain, and links to the migration guide / docs / repo.
- Embed the same announcement inside the welcome panel rendered by the CLI on `create`, `enhance`, `setup-cicd`, and `register` flows. Suppressed for Agent Garden (`-ag` / `--agent-garden`) and for `adk@` / `adk-py@` agents that already use the "Powered by ASP" line.
- Drop the rotating motto and the standard "Create production-ready AI agents on Google Cloud!" tagline so the announcement fits cleanly inside the panel.

