### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🚀 Agent Starter Pack
 
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/googlecloudplatform-agent-starter-pack)
+
 ![Version](https://img.shields.io/pypi/v/agent-starter-pack?color=blue) [![1-Minute Video Overview](https://img.shields.io/badge/1--Minute%20Overview-gray)](https://youtu.be/jHt-ZVD660g) [![Docs](https://img.shields.io/badge/Documentation-gray)](https://googlecloudplatform.github.io/agent-starter-pack/) <a href="https://studio.firebase.google.com/new?template=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fagent-starter-pack%2Ftree%2Fmain%2Fagent_starter_pack%2Fresources%2Fidx">
   <picture>
     <source


### PR DESCRIPTION
Hi! 👋 **agent-starter-pack** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/googlecloudplatform-agent-starter-pack

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building agent-starter-pack! 🙏